### PR TITLE
Fix two crash-loops that blocked deploying the moderation build

### DIFF
--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -69,22 +69,28 @@ CREATE TABLE IF NOT EXISTS blocked (
 	reason     TEXT NOT NULL,
 	name       TEXT NOT NULL,
 	created_at INTEGER NOT NULL
-);
--- Partial index: only unreviewed rows are indexed, so it stays tiny and the
--- moderation sweep never scans the full table.
-CREATE INDEX IF NOT EXISTS idx_torrents_unreviewed
-	ON torrents(created_at) WHERE reviewed_at = 0;`
+);`
 	if _, err := db.Exec(schema); err != nil {
 		db.Close()
 		return nil, err
 	}
 	// Migrate databases created before reviewed_at existed. SQLite has no
 	// ADD COLUMN IF NOT EXISTS, so a duplicate-column error is the success
-	// case on an already-migrated database.
+	// case on an already-migrated database. This must run before anything
+	// that references reviewed_at — on a pre-migration database the column
+	// does not exist yet and those statements would fail.
 	if _, err := db.Exec(`ALTER TABLE torrents ADD COLUMN reviewed_at INTEGER NOT NULL DEFAULT 0`); err != nil &&
 		!strings.Contains(err.Error(), "duplicate column name") {
 		db.Close()
 		return nil, fmt.Errorf("migrate reviewed_at: %w", err)
+	}
+	// Partial index: only unreviewed rows are indexed, so it stays tiny and the
+	// moderation sweep never scans the full table. Created after the migration
+	// above so the column it filters on is guaranteed to exist.
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_torrents_unreviewed
+		ON torrents(created_at) WHERE reviewed_at = 0`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("create unreviewed index: %w", err)
 	}
 	return &Store{db: db}, nil
 }

--- a/server/internal/store/store_test.go
+++ b/server/internal/store/store_test.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"database/sql"
+	"path/filepath"
 	"testing"
 
 	"dhtsearch/server/internal/filter"
@@ -131,4 +133,49 @@ func TestStats(t *testing.T) {
 	if m["seen"] != 5 {
 		t.Fatalf("seen=%d, want 5", m["seen"])
 	}
+}
+
+// A database created before the moderation feature has no reviewed_at column.
+// Open must migrate it in place rather than failing on the statements that
+// reference the column.
+func TestOpenMigratesPreModerationDB(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "old.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE torrents (
+		info_hash  TEXT PRIMARY KEY,
+		name       TEXT NOT NULL,
+		total_size INTEGER NOT NULL,
+		file_count INTEGER NOT NULL,
+		files_json TEXT NOT NULL,
+		created_at INTEGER NOT NULL
+	);
+	INSERT INTO torrents VALUES ('aa', 'Sintel 2010', 1024, 1, '[]', 100);`); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open on pre-migration db: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	// The pre-existing row survives and counts as unreviewed.
+	if total, _ := s.Count(); total != 1 {
+		t.Fatalf("count=%d, want 1", total)
+	}
+	n, err := s.PendingReviewCount()
+	if err != nil || n != 1 {
+		t.Fatalf("pending=%d err=%v, want 1", n, err)
+	}
+
+	// Reopening an already-migrated database is a no-op, not an error.
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen migrated db: %v", err)
+	}
+	s2.Close()
 }

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,20 @@
+import path from "path";
+import { fileURLToPath } from "url";
+
 import type { NextConfig } from "next";
+
+// Pin the project root to this directory. Next infers it by walking up for a
+// lockfile, so a stray package-lock.json anywhere above the checkout wins and
+// the standalone build gets nested under the path from that root — server.js
+// lands at .next/standalone/<path>/web/server.js instead of
+// .next/standalone/server.js, and the deployed service dies with
+// MODULE_NOT_FOUND.
+const projectRoot = path.dirname(fileURLToPath(import.meta.url));
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  turbopack: { root: projectRoot },
+  outputFileTracingRoot: projectRoot,
 };
 
 export default nextConfig;


### PR DESCRIPTION
Deploying `e9f9cd4` to a live server crash-looped both services. Two independent causes, both hit only against real deployment state, so neither shows up in a fresh local run.

## 1. Store migration ran too late

`Open()` executed the whole schema batch in one `Exec`, and that batch ended with the partial index on `reviewed_at`. On a database created before the moderation feature, `CREATE TABLE IF NOT EXISTS torrents` is a no-op, so the index statement referenced a column that did not exist yet and the batch failed — *before* the `ALTER TABLE` that would have added it.

```
store: SQL logic error: no such column: reviewed_at (1)
dhtsearch-api.service: Main process exited, code=exited, status=1/FAILURE
```

Index creation now runs after the migration. Covered by a test that hand-builds a pre-migration database and opens it; it fails with the exact production error without the fix, and also asserts that reopening an already-migrated database stays a no-op.

## 2. Standalone build had no top-level `server.js`

Next infers the project root by walking up for a lockfile, so a stray `package-lock.json` above the checkout wins. The standalone output was then nested under the path from that root:

```
.next/standalone/orca/workspaces/dhtsearch/pollock/web/server.js   # actual
.next/standalone/server.js                                          # expected by deploy.sh
```

`deploy.sh` uploaded a tree with no `server.js` at the top and the web service died with `MODULE_NOT_FOUND`. Pinning `turbopack.root` and `outputFileTracingRoot` to the web directory makes the layout independent of whatever sits above the checkout, and drops the "inferred your workspace root" build warning.

## Verification

- `gofmt -l`, `go vet ./...`, `go test ./...` — clean
- `npm run lint`, `npm run build` — clean, `server.js` at the standalone root
- Deployed to the live server: both units `active`, existing 167 torrents preserved through the migration, moderator started (`deepseek-v4-flash interval=1h0m0s batch=50 dry-run=false`), public site serving search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)