### PR TITLE
Install the launchd runtime under ~/Library instead of the checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,24 @@ echo 'DEPLOY_HOST=user@example.com' > .deploy.env   # gitignored
 ./scripts/sync-to-remote.sh                          # 手动同步一次
 ```
 
-原理：本地实例把数据写到 `data/local.db`，脚本按水位线（`data/last_sync_ts`）导出新增行到小 delta 文件，scp 到服务器后 `INSERT OR IGNORE` 合并（按 info_hash 去重），只传输增量。
+原理：本地实例把数据写到 `local.db`，脚本按水位线（`last_sync_ts`）导出新增行到小 delta 文件，scp 到服务器后 `INSERT OR IGNORE` 合并（按 info_hash 去重），只传输增量。
 
 macOS 上可用 launchd 常驻/定时（安装后本地爬虫 API 在 `127.0.0.1:8089`，同步每 30 分钟一次）：
 
 ```bash
-./scripts/launchd/install.sh   # 生成并加载 ~/Library/LaunchAgents/com.dhtsearch.{crawler,sync}.plist
+./scripts/launchd/install.sh   # 构建二进制、安装脚本、加载两个 agent
 ```
+
+拉取新代码后重新执行同一条命令即可更新（会重新编译并 reload agent）。
+
+运行时文件（二进制、数据库、日志、脚本副本）装在 checkout **之外**：
+
+| 路径 | 内容 |
+| --- | --- |
+| `~/Library/Application Support/dhtsearch/` | `bin/`、`local.db`、`last_sync_ts`、`.deploy.env`（可用 `DHTSEARCH_STATE_DIR` 覆盖） |
+| `~/Library/Logs/dhtsearch/` | `crawler.log`、`sync.log` |
+
+> 这不是洁癖：launchd agent 对非系统卷（`/Volumes/...`）没有 TCC 权限，仓库放在外置盘时 agent **读写都会失败**——spawn 直接以 `EX_CONFIG (78)` 退出，或每次文件操作报 `Operation not permitted`。`$HOME` 下的路径不需要任何授权。
 
 ## 注意
 

--- a/scripts/launchd/com.dhtsearch.crawler.plist
+++ b/scripts/launchd/com.dhtsearch.crawler.plist
@@ -4,18 +4,18 @@
 <dict>
     <key>Label</key><string>com.dhtsearch.crawler</string>
     <key>ProgramArguments</key>
-    <array><string>__PROJECT_DIR__/bin/dhtsearch-server</string></array>
-    <key>WorkingDirectory</key><string>__PROJECT_DIR__</string>
+    <array><string>__STATE_DIR__/bin/dhtsearch-server</string></array>
+    <key>WorkingDirectory</key><string>__STATE_DIR__</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>HTTP_ADDR</key><string>127.0.0.1:8089</string>
-        <key>DB_PATH</key><string>__PROJECT_DIR__/data/local.db</string>
+        <key>DB_PATH</key><string>__STATE_DIR__/local.db</string>
         <key>CRAWL_ENABLED</key><string>true</string>
         <key>META_WORKERS</key><string>16</string>
     </dict>
     <key>KeepAlive</key><true/>
     <key>RunAtLoad</key><true/>
-    <key>StandardOutPath</key><string>__PROJECT_DIR__/data/logs/crawler.log</string>
-    <key>StandardErrorPath</key><string>__PROJECT_DIR__/data/logs/crawler.log</string>
+    <key>StandardOutPath</key><string>__LOG_DIR__/crawler.log</string>
+    <key>StandardErrorPath</key><string>__LOG_DIR__/crawler.log</string>
 </dict>
 </plist>

--- a/scripts/launchd/com.dhtsearch.sync.plist
+++ b/scripts/launchd/com.dhtsearch.sync.plist
@@ -4,11 +4,11 @@
 <dict>
     <key>Label</key><string>com.dhtsearch.sync</string>
     <key>ProgramArguments</key>
-    <array><string>/bin/bash</string><string>__PROJECT_DIR__/scripts/sync-to-remote.sh</string></array>
-    <key>WorkingDirectory</key><string>__PROJECT_DIR__</string>
+    <array><string>/bin/bash</string><string>__STATE_DIR__/bin/sync-to-remote.sh</string></array>
+    <key>WorkingDirectory</key><string>__STATE_DIR__</string>
     <key>StartInterval</key><integer>1800</integer>
     <key>RunAtLoad</key><false/>
-    <key>StandardOutPath</key><string>__PROJECT_DIR__/data/logs/sync.log</string>
-    <key>StandardErrorPath</key><string>__PROJECT_DIR__/data/logs/sync.log</string>
+    <key>StandardOutPath</key><string>__LOG_DIR__/sync.log</string>
+    <key>StandardErrorPath</key><string>__LOG_DIR__/sync.log</string>
 </dict>
 </plist>

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -1,10 +1,57 @@
 #!/usr/bin/env bash
-# Install launchd agents for the local crawler + periodic sync (macOS).
+# Install (or update) the launchd agents for the local crawler + periodic sync.
+#
+# Re-run this after pulling new code: it rebuilds the binary, refreshes the
+# installed scripts and reloads both agents.
+#
+# Everything the agents touch at runtime — binary, database, logs, scripts —
+# is installed under STATE_DIR/LOG_DIR, deliberately NOT in the checkout.
+# launchd agents get no TCC access to non-system volumes, so a checkout on an
+# external disk (/Volumes/...) is unreadable and unwritable to them: the job
+# dies at spawn with EX_CONFIG (78), or every file operation fails with
+# "Operation not permitted". Paths under $HOME need no permission grant.
+#
+#   DHTSEARCH_STATE_DIR   override the state dir (default below)
 set -euo pipefail
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-for name in com.dhtsearch.crawler com.dhtsearch.sync; do
-    sed "s|__PROJECT_DIR__|$ROOT_DIR|g" "$ROOT_DIR/scripts/launchd/$name.plist" > "$HOME/Library/LaunchAgents/$name.plist"
-    launchctl unload "$HOME/Library/LaunchAgents/$name.plist" 2>/dev/null || true
-    launchctl load -w "$HOME/Library/LaunchAgents/$name.plist"
-    echo "installed $name"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+STATE_DIR="${DHTSEARCH_STATE_DIR:-$HOME/Library/Application Support/dhtsearch}"
+LOG_DIR="$HOME/Library/Logs/dhtsearch"
+AGENT_DIR="$HOME/Library/LaunchAgents"
+
+mkdir -p "$STATE_DIR/bin" "$LOG_DIR" "$AGENT_DIR"
+
+echo "==> Building crawler binary into $STATE_DIR/bin"
+(cd "$ROOT_DIR/server" && go build -o "$STATE_DIR/bin/dhtsearch-server" ./cmd/server)
+
+echo "==> Installing sync script"
+install -m 755 "$ROOT_DIR/scripts/sync-to-remote.sh" "$STATE_DIR/bin/sync-to-remote.sh"
+
+# The sync job reads DEPLOY_HOST from .deploy.env in its state dir, so the
+# gitignored copy in the checkout has to come along (the agent cannot read the
+# checkout). Refreshed on every run so edits in the repo take effect.
+if [ -f "$ROOT_DIR/.deploy.env" ]; then
+    install -m 600 "$ROOT_DIR/.deploy.env" "$STATE_DIR/.deploy.env"
+else
+    echo "    note: no .deploy.env in the checkout — the sync agent will fail" \
+         "until $STATE_DIR/.deploy.env exists (echo 'DEPLOY_HOST=user@host' > ...)"
+fi
+
+# One-time migration from the old in-checkout layout.
+for f in local.db last_sync_ts; do
+    if [ -f "$ROOT_DIR/data/$f" ] && [ ! -e "$STATE_DIR/$f" ]; then
+        cp -p "$ROOT_DIR/data/$f" "$STATE_DIR/$f"
+        echo "    migrated data/$f -> $STATE_DIR/$f"
+    fi
 done
+
+echo "==> Loading agents"
+for name in com.dhtsearch.crawler com.dhtsearch.sync; do
+    sed -e "s|__STATE_DIR__|$STATE_DIR|g" -e "s|__LOG_DIR__|$LOG_DIR|g" \
+        "$ROOT_DIR/scripts/launchd/$name.plist" > "$AGENT_DIR/$name.plist"
+    launchctl unload "$AGENT_DIR/$name.plist" 2>/dev/null || true
+    launchctl load -w "$AGENT_DIR/$name.plist"
+    echo "    installed $name"
+done
+
+echo "==> Done. Crawler API on http://127.0.0.1:8089, logs in $LOG_DIR"

--- a/scripts/sync-to-remote.sh
+++ b/scripts/sync-to-remote.sh
@@ -7,9 +7,14 @@
 # INSERT OR IGNORE (dedup by info_hash primary key). Only the delta crosses
 # the network.
 #
-# The remote host is NOT stored here. It comes from $DEPLOY_HOST or the
-# gitignored .deploy.env file in the repo root:
+# The remote host is NOT stored here. It comes from $DEPLOY_HOST or a
+# gitignored .deploy.env, looked up in the repo root and then in the state dir:
 #   echo 'DEPLOY_HOST=user@example.com' > .deploy.env
+#
+# The crawler's database lives in the state dir rather than the checkout, so
+# the launchd agent can reach it — see scripts/launchd/install.sh. Override
+# with DHTSEARCH_STATE_DIR, or point LOCAL_DB/WATERMARK_FILE somewhere else
+# outright.
 #
 # Optional: DEPLOY_DIR (default /opt/dhtsearch), SYNC_INTERVAL is controlled
 # by the scheduler (launchd/cron), not this script.
@@ -17,12 +22,17 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-[ -f "$ROOT_DIR/.deploy.env" ] && . "$ROOT_DIR/.deploy.env"
+STATE_DIR="${DHTSEARCH_STATE_DIR:-$HOME/Library/Application Support/dhtsearch}"
+for f in "$ROOT_DIR/.deploy.env" "$STATE_DIR/.deploy.env"; do
+    # `if` rather than `[ ... ] && .` so a miss on the last candidate does not
+    # make the loop exit non-zero and trip `set -e`.
+    if [ -f "$f" ]; then . "$f"; break; fi
+done
 
 DEPLOY_HOST="${DEPLOY_HOST:?DEPLOY_HOST is required (env or .deploy.env)}"
 DEPLOY_DIR="${DEPLOY_DIR:-/opt/dhtsearch}"
-LOCAL_DB="$ROOT_DIR/data/local.db"
-WATERMARK_FILE="$ROOT_DIR/data/last_sync_ts"
+LOCAL_DB="${LOCAL_DB:-$STATE_DIR/local.db}"
+WATERMARK_FILE="${WATERMARK_FILE:-$STATE_DIR/last_sync_ts}"
 SQLITE=/usr/bin/sqlite3
 
 [ -f "$LOCAL_DB" ] || { echo "local db not found: $LOCAL_DB"; exit 1; }


### PR DESCRIPTION
> Stacked on #2 — review that one first; this PR's diff is only the `scripts/` + README changes.

Both local agents were dead. `launchctl list` showed no PID and exit code 78 (`EX_CONFIG`) for `com.dhtsearch.crawler`, with no log file ever created.

## Cause

launchd agents get no TCC access to non-system volumes, and the checkout lives on an external disk (`/Volumes/DATA`). Probe agents pinned down exactly what is and isn't allowed:

| operation | result |
| --- | --- |
| launchd execs a binary on the volume | works |
| job writes a file on the volume | `Operation not permitted` |
| job reads a file on the volume | `Operation not permitted` |
| launchd opens `StandardOutPath` on the volume | job dies at spawn, `EX_CONFIG (78)` |

So the crawler never started (its log path was on the volume), and even once that was worked around it could not write `local.db`. The sync agent was equally dead: `/bin/bash` could not read the script, and `chdir` to the working directory failed.

This is not specific to this machine — any checkout outside the system volume hits it.

## Change

Everything the agents touch at runtime is installed outside the checkout, which stays the source of truth for code only:

| path | contents |
| --- | --- |
| `~/Library/Application Support/dhtsearch/` | `bin/`, `local.db`, `last_sync_ts`, `.deploy.env` (override with `DHTSEARCH_STATE_DIR`) |
| `~/Library/Logs/dhtsearch/` | `crawler.log`, `sync.log` |

- `install.sh` now builds the binary, installs the sync script and `.deploy.env`, migrates `local.db`/`last_sync_ts` from the old in-checkout location, and reloads both agents — so re-running it is also the update path after pulling.
- `sync-to-remote.sh` resolves the DB and watermark from the state dir (`LOCAL_DB`/`WATERMARK_FILE` still override) and looks for `.deploy.env` in the checkout first, then the state dir.
- Drive-by: `install.sh` resolved `ROOT_DIR` one directory too high, so it looked for `scripts/scripts/launchd/`. The `.deploy.env` lookup loop uses `if` rather than `[ … ] && .` so a miss on the last candidate does not trip `set -e`.

## Verification

Installed and running on macOS: crawler up under launchd serving `127.0.0.1:8089/api/healthz`, writing to the state-dir database; sync agent kickstarted and completed cleanly ("nothing new to sync").

Not fixed here, and unrelated to the install: the local crawler harvests nothing on this network — `nettop` shows ~2.5 KB/s out against ~87 B/s in, so its DHT queries get no replies with VPN tunnels up. Discovery needs inbound `get_peers` or BEP-51 replies. The server has a public IP and crawls fine on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)