### PR TITLE
Drop the zero infohash before it panics the metadata client

### DIFF
--- a/server/internal/crawler/crawler.go
+++ b/server/internal/crawler/crawler.go
@@ -226,6 +226,13 @@ func (c *Crawler) onQuery(query *krpc.Msg, _ net.Addr) bool {
 
 // push records an infohash if new, with FIFO eviction over the capacity.
 func (c *Crawler) push(ih [20]byte) {
+	// The all-zero infohash is not a torrent: peers send it in malformed or
+	// probing queries, and BEP 51 samples occasionally carry it. It has to be
+	// dropped here because anacrolix/torrent panics rather than errors when
+	// AddMagnet is handed one, which takes the whole process down.
+	if ih == ([20]byte{}) {
+		return
+	}
 	c.mu.Lock()
 	if _, ok := c.seen[ih]; ok {
 		c.mu.Unlock()

--- a/server/internal/crawler/crawler_test.go
+++ b/server/internal/crawler/crawler_test.go
@@ -144,3 +144,27 @@ func TestPushDedupesAndFillsChannel(t *testing.T) {
 		t.Fatalf("hex=%q", got)
 	}
 }
+
+// A zero infohash must never reach the fetcher: anacrolix/torrent panics on
+// it instead of returning an error, which killed the process in production
+// once sampling volume made it a regular occurrence.
+func TestPushDropsZeroInfohash(t *testing.T) {
+	c := testCrawler()
+	c.out = make(chan string, 4)
+
+	c.push([20]byte{})
+	if len(c.out) != 0 {
+		t.Fatalf("emitted=%d, want 0 (zero infohash must be dropped)", len(c.out))
+	}
+	if n := c.SeenCount(); n != 0 {
+		t.Fatalf("seen=%d, want 0 (zero infohash should not occupy the dedup set)", n)
+	}
+
+	// A hash that merely starts with zero bytes is legitimate.
+	var almost [20]byte
+	almost[19] = 1
+	c.push(almost)
+	if len(c.out) != 1 {
+		t.Fatalf("emitted=%d, want 1 (non-zero hash should pass)", len(c.out))
+	}
+}

--- a/server/internal/metadata/fetcher.go
+++ b/server/internal/metadata/fetcher.go
@@ -121,6 +121,14 @@ func (f *Fetcher) worker(ctx context.Context, in <-chan string, onRecord func(Re
 // the torrent afterwards.
 func (f *Fetcher) fetch(ctx context.Context, hexHash string) (Record, bool) {
 	rec := Record{InfoHash: hexHash}
+	// AddMagnet panics (rather than returning an error) on a zero or
+	// malformed infohash, and a panic in a worker takes the process with it.
+	// The crawler already filters these, but this is the last line before an
+	// untrusted value reaches the library, so check here too.
+	if !validInfohash(hexHash) {
+		f.count(&f.failed)
+		return rec, false
+	}
 	t, err := f.client.AddMagnet("magnet:?xt=urn:btih:" + hexHash)
 	if err != nil {
 		f.count(&f.failed)
@@ -158,6 +166,27 @@ func (f *Fetcher) fetch(ctx context.Context, hexHash string) (Record, bool) {
 	}
 	f.count(&f.fetched)
 	return rec, true
+}
+
+// validInfohash reports whether s is a 40-character hex infohash that is not
+// all zeros.
+func validInfohash(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+	zero := true
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= '0' && c <= '9', c >= 'a' && c <= 'f', c >= 'A' && c <= 'F':
+		default:
+			return false
+		}
+		if c != '0' {
+			zero = false
+		}
+	}
+	return !zero
 }
 
 func (f *Fetcher) count(p *int64) {

--- a/server/internal/metadata/fetcher_test.go
+++ b/server/internal/metadata/fetcher_test.go
@@ -1,0 +1,30 @@
+package metadata
+
+import "testing"
+
+// The zero infohash reaches AddMagnet as a panic, not an error, so rejecting
+// it before the library sees it is what keeps a worker from taking the
+// process down.
+func TestValidInfohash(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"typical", "97a29535b9e2f0e46a1b09a4b0c0e4f0a1b2c3d4", true},
+		{"uppercase", "97A29535B9E2F0E46A1B09A4B0C0E4F0A1B2C3D4", true},
+		{"all zeros", "0000000000000000000000000000000000000000", false},
+		{"empty", "", false},
+		{"too short", "97a29535", false},
+		{"too long", "97a29535b9e2f0e46a1b09a4b0c0e4f0a1b2c3d4f", false},
+		{"non-hex", "97a29535b9e2f0e46a1b09a4b0c0e4f0a1b2c3zz", false},
+		{"leading zeros are fine", "0000000000000000000000000000000000000001", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := validInfohash(tc.in); got != tc.want {
+				t.Fatalf("validInfohash(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The service crash-looped 5 times overnight under the new crawl rates:

```
panic: is zero
github.com/anacrolix/missinggo/v2/panicif.Zero
github.com/anacrolix/torrent.(*Client).AddTorrentOpt   client.go:1514
github.com/anacrolix/torrent.(*Client).AddMagnet
dhtsearch/server/internal/metadata.(*Fetcher).fetch    fetcher.go:124
```

Peers send the all-zero infohash in malformed and probing queries, and BEP 51 samples occasionally carry it. `anacrolix/torrent` asserts on it inside `AddMagnet` rather than returning an error, so one bad value off the network takes the entire process down — every worker, the crawler and the API with it.

This was always reachable. It only became routine when sampling went from 3 queries/min to thousands: raising throughput turns rare inputs into regular ones.

## Change

Dropped in the crawler where infohashes enter, and checked again in the fetcher — that is the last point before an untrusted value reaches a library that panics rather than errors, and the blast radius of missing it is the whole process rather than one fetch.

Tests cover the boundary that matters: an all-zero hash is rejected while a hash that merely *starts* with zero bytes is not, plus length and non-hex rejection.

## Related: conntrack exhaustion (fixed on the host, not in this PR)

The same log showed a flood of `sendto: operation not permitted`, which was not the crawler's fault directly:

```
nf_conntrack: table full, dropping packet
net.netfilter.nf_conntrack_count = 65535 / max = 65536
```

DHT crawling opens far more short-lived UDP flows than the stock 65536-entry table holds, and once it is full the kernel drops packets **for every service on the host**, not just this one. Raised to 262144 with shorter idle UDP timeouts (20s / 45s) via `/etc/sysctl.d/99-dhtsearch-conntrack.conf` on the server. Worth knowing before deploying this crawler anywhere else.

## Verification

`gofmt -l`, `go vet ./...`, `go test ./...` clean. Deployed; sustained rate before the crash-loop was 34.3 torrents/min over 16 hours (33,903 indexed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)