### PR TITLE
Make long torrent names and file paths readable in search results

### DIFF
--- a/web/components/ResultCard.tsx
+++ b/web/components/ResultCard.tsx
@@ -2,7 +2,12 @@
 
 import { useState } from "react";
 import type { SearchResult } from "@/lib/api";
-import { formatRelativeTime, formatSize } from "@/lib/format";
+import {
+  commonDirPrefix,
+  formatRelativeTime,
+  formatSize,
+  shortenDir,
+} from "@/lib/format";
 import CopyMagnetButton from "./CopyMagnetButton";
 
 const MAX_FILES_SHOWN = 10;
@@ -11,6 +16,9 @@ export default function ResultCard({ result }: { result: SearchResult }) {
   const [expanded, setExpanded] = useState(false);
   const files = result.files ?? [];
   const shownFiles = files.slice(0, MAX_FILES_SHOWN);
+  // Computed over every file, not just the shown ones, so the prefix doesn't
+  // shift when the "+N more" tail is hidden.
+  const root = commonDirPrefix(files.map((f) => f.path));
 
   return (
     <div className="rounded-lg border border-zinc-800 bg-zinc-900/60 p-4 transition-colors hover:border-zinc-700">
@@ -20,7 +28,14 @@ export default function ResultCard({ result }: { result: SearchResult }) {
           className="min-w-0 flex-1 text-left"
           title={result.name}
         >
-          <h3 className="truncate text-sm font-medium text-emerald-400 hover:text-emerald-300 sm:text-base">
+          {/* Release names carry their resolution, codec and group at the very
+              end, so clamp to two lines rather than truncating to one — and
+              drop the clamp entirely once the card is open. */}
+          <h3
+            className={`text-sm font-medium wrap-anywhere text-emerald-400 hover:text-emerald-300 sm:text-base ${
+              expanded ? "" : "line-clamp-2"
+            }`}
+          >
             {result.name || "(未命名)"}
           </h3>
           <p className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-zinc-400">
@@ -35,23 +50,56 @@ export default function ResultCard({ result }: { result: SearchResult }) {
       {expanded && (
         <div className="mt-3 rounded-md border border-zinc-800 bg-zinc-950/60 p-3">
           {files.length > 0 ? (
-            <ul className="space-y-1 text-xs text-zinc-400">
-              {shownFiles.map((f, i) => (
-                <li key={i} className="flex items-baseline justify-between gap-3">
-                  <span className="min-w-0 truncate font-mono">{f.path}</span>
-                  <span className="shrink-0 text-zinc-500">{formatSize(f.size)}</span>
-                </li>
-              ))}
-              {files.length > MAX_FILES_SHOWN && (
-                <li className="pt-1 text-zinc-500">
-                  … 其余 {files.length - MAX_FILES_SHOWN} 个文件未显示
-                </li>
+            <>
+              {root && (
+                <p
+                  className="mb-2 line-clamp-2 border-b border-zinc-800/80 pb-2 font-mono text-[11px] wrap-anywhere text-zinc-500"
+                  title={root}
+                >
+                  📁 {root}
+                </p>
               )}
-            </ul>
+              <ul className="space-y-1.5 text-xs text-zinc-400">
+                {shownFiles.map((f, i) => {
+                  const rest = f.path.slice(root.length);
+                  const cut = rest.lastIndexOf("/");
+                  const dir = cut >= 0 ? rest.slice(0, cut + 1) : "";
+                  const name = cut >= 0 ? rest.slice(cut + 1) : rest;
+                  return (
+                    <li key={i} className="flex items-baseline justify-between gap-3">
+                      <span className="min-w-0 font-mono" title={f.path}>
+                        {/* The directory is context, so it may truncate; the
+                            file name is what tells two rows apart, so it wraps
+                            in full on its own line. */}
+                        {dir && (
+                          <span className="block truncate text-zinc-600">
+                            {shortenDir(dir)}
+                          </span>
+                        )}
+                        <span className="block wrap-anywhere text-zinc-300">
+                          {name}
+                        </span>
+                      </span>
+                      <span className="shrink-0 tabular-nums text-zinc-500">
+                        {formatSize(f.size)}
+                      </span>
+                    </li>
+                  );
+                })}
+                {files.length > MAX_FILES_SHOWN && (
+                  <li className="pt-1 text-zinc-500">
+                    … 其余 {files.length - MAX_FILES_SHOWN} 个文件未显示
+                  </li>
+                )}
+              </ul>
+            </>
           ) : (
             <p className="text-xs text-zinc-500">暂无文件列表信息</p>
           )}
-          <p className="mt-2 break-all font-mono text-[11px] leading-relaxed text-zinc-600">
+          <p
+            className="mt-3 line-clamp-2 border-t border-zinc-800/80 pt-2 font-mono text-[11px] leading-relaxed break-all text-zinc-600"
+            title={result.magnet}
+          >
             {result.magnet}
           </p>
         </div>

--- a/web/lib/format.ts
+++ b/web/lib/format.ts
@@ -41,3 +41,42 @@ export function formatCount(n: number | undefined | null): string {
   if (n === undefined || n === null || !Number.isFinite(n)) return "-";
   return n.toLocaleString("zh-CN");
 }
+
+// Longest directory prefix (ending in "/") shared by every path.
+//
+// Torrents almost always wrap their contents in one top-level folder named
+// after the torrent itself. Rendering that prefix on every row pushes the only
+// distinguishing part — the file name — past the right edge, making unrelated
+// files look identical. Callers strip the prefix and show it once instead.
+export function commonDirPrefix(paths: string[]): string {
+  if (paths.length < 2) return "";
+  let prefix = paths[0].slice(0, paths[0].lastIndexOf("/") + 1);
+  for (const p of paths.slice(1)) {
+    while (prefix && !p.startsWith(prefix)) {
+      // Drop the trailing "/" then back up to the previous separator.
+      prefix = prefix.slice(0, prefix.lastIndexOf("/", prefix.length - 2) + 1);
+    }
+    if (!prefix) return "";
+  }
+  return prefix;
+}
+
+// Shorten a directory path from the left, e.g. "A.Very.Long.Release/Subs/" ->
+// ".../Subs/". The deepest segment says what the file is for, while the release
+// folder at the front is both the longest and the least informative, so keep
+// trailing segments while they fit in the budget and elide the rest. A single
+// trailing segment is kept whatever its length — CSS truncates the overflow.
+export function shortenDir(dir: string, maxChars = 48): string {
+  if (dir.length <= maxChars) return dir;
+  const segments = dir.split("/").filter(Boolean);
+  const kept: string[] = [];
+  let used = 0;
+  for (let i = segments.length - 1; i >= 0; i--) {
+    const cost = segments[i].length + 1;
+    if (kept.length > 0 && used + cost > maxChars) break;
+    kept.unshift(segments[i]);
+    used += cost;
+  }
+  const elided = kept.length < segments.length ? "…/" : "";
+  return `${elided}${kept.join("/")}/`;
+}


### PR DESCRIPTION
## Problem

Both the result title and the expanded file list used single-line `truncate`, which cuts the tail — and the tail is where the information lives.

- **Titles**: release names put resolution, codec and group at the end, so `Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX.HEVC.DV.HDR10Plus.TrueHD…` told you nothing past the year.
- **File rows**: torrents wrap their contents in one top-level folder named after the torrent, so the `.mkv`, the English `.srt` and the Chinese `.srt` all rendered as the *same* truncated prefix — three rows, visually identical.

## Changes

`web/components/ResultCard.tsx`, `web/lib/format.ts`:

- Titles clamp to two wrapped lines (`wrap-anywhere` handles both dotted ASCII and CJK) and show in full once the card is expanded.
- File rows strip the directory prefix shared by every file and show it once as a `📁` header. The remainder splits into a muted, truncatable directory line (context) and the file name, which wraps in full and never truncates (the part that tells rows apart).
- Long directories elide from the left — `…/Subs/` — so the deepest, most specific segment survives instead of the useless release-folder prefix.
- Sizes use tabular numerals; the magnet URI clamps to two lines.

Full text stays available via `title` tooltips throughout.

## Verification

Seeded the local DB with five torrents covering the hard cases (127-char dotted release name, CJK title with bracket noise, a 118-char unbroken token, a 42-file collection, a short ordinary name), ran the Go backend plus `next dev`, and checked the rendering in Chrome — collapsed, expanded, and at a 360px container. No horizontal overflow at narrow width. The DB was restored to its original empty state afterwards.

`tsc --noEmit`, `npm run lint` and `npm run build` all pass. `commonDirPrefix` and `shortenDir` were exercised directly against edge cases (sibling dirs, partial-segment overlap like `AB/` vs `ABC/`, root-level files, single oversized segments).

## Not changed

- The search box overflows its container below ~360px. Pre-existing and unrelated to text display; only observed under an artificial container constraint, not confirmed at a real mobile viewport.
- The collapsed title stays at a 2-line clamp on mobile, where it shows relatively little. Bumping to 3 lines on small screens is a density tradeoff left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)