### PR TITLE
Refine search result text display on phones

### DIFF
--- a/web/components/CopyMagnetButton.tsx
+++ b/web/components/CopyMagnetButton.tsx
@@ -21,16 +21,58 @@ export default function CopyMagnetButton({ magnet }: { magnet: string }) {
     setTimeout(() => setCopied(false), 1500);
   }
 
+  const label = copied ? "已复制磁力链接" : "复制磁力链接";
+
   return (
+    // The full label costs a quarter of a phone's width and leaves the torrent
+    // name almost no room, so below sm: this collapses to a square icon button.
     <button
       onClick={copy}
-      className={`shrink-0 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${
+      title={label}
+      aria-label={label}
+      className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-md border text-xs font-medium transition-colors sm:h-auto sm:w-auto sm:px-3 sm:py-1.5 ${
         copied
           ? "border-emerald-600 bg-emerald-600/20 text-emerald-400"
           : "border-zinc-700 bg-zinc-800 text-zinc-300 hover:border-emerald-600 hover:text-emerald-400"
       }`}
     >
-      {copied ? "✓ 已复制" : "复制磁力链接"}
+      <span aria-hidden className="sm:hidden">
+        {copied ? <CheckIcon /> : <LinkIcon />}
+      </span>
+      <span className="hidden sm:inline">{copied ? "✓ 已复制" : "复制磁力链接"}</span>
     </button>
+  );
+}
+
+function LinkIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-4 w-4"
+    >
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-4 w-4"
+    >
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
   );
 }

--- a/web/components/ResultCard.tsx
+++ b/web/components/ResultCard.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { SearchResult } from "@/lib/api";
 import {
   commonDirPrefix,
+  formatCount,
   formatRelativeTime,
   formatSize,
   shortenDir,
@@ -16,6 +17,11 @@ export default function ResultCard({ result }: { result: SearchResult }) {
   const [expanded, setExpanded] = useState(false);
   const files = result.files ?? [];
   const shownFiles = files.slice(0, MAX_FILES_SHOWN);
+  // The crawler stores at most 50 file entries but records the real count, so
+  // count what's hidden against file_count — otherwise a 3136-file torrent
+  // claims only 40 files are missing.
+  const totalFiles = Math.max(result.file_count ?? 0, files.length);
+  const hiddenFiles = totalFiles - shownFiles.length;
   // Computed over every file, not just the shown ones, so the prefix doesn't
   // shift when the "+N more" tail is hidden.
   const root = commonDirPrefix(files.map((f) => f.path));
@@ -30,17 +36,18 @@ export default function ResultCard({ result }: { result: SearchResult }) {
         >
           {/* Release names carry their resolution, codec and group at the very
               end, so clamp to two lines rather than truncating to one — and
-              drop the clamp entirely once the card is open. */}
+              drop the clamp entirely once the card is open. Phone lines hold
+              far fewer characters, so they get a third line to compensate. */}
           <h3
             className={`text-sm font-medium wrap-anywhere text-emerald-400 hover:text-emerald-300 sm:text-base ${
-              expanded ? "" : "line-clamp-2"
+              expanded ? "" : "line-clamp-3 sm:line-clamp-2"
             }`}
           >
             {result.name || "(未命名)"}
           </h3>
           <p className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-zinc-400">
             <span>{formatSize(result.total_size)}</span>
-            <span>{result.file_count ?? files.length} 个文件</span>
+            <span>{formatCount(totalFiles)} 个文件</span>
             <span>收录于 {formatRelativeTime(result.created_at)}</span>
           </p>
         </button>
@@ -86,9 +93,9 @@ export default function ResultCard({ result }: { result: SearchResult }) {
                     </li>
                   );
                 })}
-                {files.length > MAX_FILES_SHOWN && (
+                {hiddenFiles > 0 && (
                   <li className="pt-1 text-zinc-500">
-                    … 其余 {files.length - MAX_FILES_SHOWN} 个文件未显示
+                    … 其余 {formatCount(hiddenFiles)} 个文件未显示
                   </li>
                 )}
               </ul>

--- a/web/components/SearchBox.tsx
+++ b/web/components/SearchBox.tsx
@@ -27,7 +27,10 @@ export default function SearchBox({ initialQuery = "", large = false }: SearchBo
           onChange={(e) => setQ(e.target.value)}
           placeholder="搜索磁力链接 / 资源名称…"
           autoFocus={large}
-          className={`flex-1 rounded-lg border border-zinc-700 bg-zinc-900 text-zinc-100 placeholder-zinc-500 outline-none focus:border-emerald-500 ${
+          // min-w-0 lets the input shrink past its intrinsic size; without it
+          // the row overflows narrow viewports and pushes the submit button
+          // off-screen.
+          className={`min-w-0 flex-1 rounded-lg border border-zinc-700 bg-zinc-900 text-zinc-100 placeholder-zinc-500 outline-none focus:border-emerald-500 ${
             large ? "px-5 py-3.5 text-lg" : "px-4 py-2 text-sm"
           }`}
         />


### PR DESCRIPTION
Follow-up to #7, which improved long-text display but was only verified at desktop width and under an artificial container constraint.

Verified here in a **real 390px viewport** — rendered in an iframe, since Chrome refused to resize the window below ~1281px, and media queries resolve against the iframe's own viewport so Tailwind's `sm:` breakpoint behaves exactly as on a phone. Tested against 60 torrent records copied from production (names 8–112 chars, median 40) rather than invented samples.

## What was broken

**1. Horizontal overflow.** The page scrolled sideways on mobile — `scrollWidth` 393 against a 390px viewport. The search `<input>` is a flex item with no `min-w-0`, so its default `min-width: auto` kept it at intrinsic width and pushed the 搜索 button off-screen.

**2. The copy button was starving the title.** `复制磁力链接` measured **98px of 390px** — a quarter of the screen — leaving the torrent name a 214px column, so names that fit fine on desktop truncated on mobile.

**3. A wrong number, not just cramped text.** The crawler caps stored file entries at 50 (`server/internal/metadata/fetcher.go:68`) but records the true count. A 3136-file torrent showed `3136 个文件` in the header and `其余 40 个文件未显示` below it — off by 3,086.

## Changes

- `SearchBox.tsx` — `min-w-0` on the input. Overflow gone (`scrollWidth` 390 = viewport 390).
- `CopyMagnetButton.tsx` — below `sm:` collapses to a 40x40 icon button (inline SVG link/check using `currentColor`), keeping its accessible name via `aria-label` and `title`. Title column **214px → 272px**. Desktop keeps the full text label, unchanged.
- `ResultCard.tsx` — `line-clamp-3 sm:line-clamp-2`, since a phone line holds far fewer characters; hidden-file count derived from `file_count`; both counts use thousands separators (`3,136 个文件` / `其余 3,126 个文件未显示`).

Titles that previously truncated now render in full at 390px, including the CJK case (`金特务：本色回归.Agent.Kim.Reactivated.S01E08...`).

## Verification

`tsc --noEmit`, `npm run lint` and `npm run build` all pass. Desktop rendering confirmed unchanged. Local DB restored to its original empty state afterwards.

## Not changed

The header is still tight at 390px — the input placeholder clips to `搜索磁力链接 / 资源名`. Fixing it means either a shorter mobile placeholder or stacking the header; both are design calls rather than bugs, so they're left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)