### PR TITLE
Strip advertising from torrent titles during the hourly audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ LLM 审核相关（见下文「LLM 二次审核」）：
 | `MODERATION_BATCH_SIZE` | `50` | 每次请求送审的标题数 |
 | `MODERATION_MAX_BATCHES` | `40` | 每轮最多几批（0 = 不限），用于封顶开销 |
 | `MODERATION_DRY_RUN` | `false` | 只打日志不删除 |
+| `MODERATION_TRIM_TITLES` | `true` | 顺带清理标题里的广告文字 |
 
 ### 前端
 
@@ -132,7 +133,7 @@ npm run dev                  # 开发
 - **不会复活**：删除的 infohash 写入 `blocked` 表，爬虫与增量同步都不会再把它加回来
 - **失败安全**：API 报错时该批不标记已审，下轮重试；模型返回无法解析、标签未知或漏项一律按 `ok` 处理，绝不因不确定而删除
 - **开销可控**：`MODERATION_MAX_BATCHES × MODERATION_BATCH_SIZE` 即每小时上限（默认 2000 条／小时）
-- **提示词**：明确要求「盗版本身不算垃圾」，否则模型会把整个库都判成垃圾；见 `server/internal/moderator/moderator.go` 的 `systemPrompt`
+- **提示词**：明确要求「盗版本身不算垃圾」，否则模型会把整个库都判成垃圾；见 `server/internal/moderator/moderator.go` 的 `systemPromptFor`
 
 首次开启建议先跑一轮 dry-run 看日志，确认判定符合预期再放开删除：
 
@@ -141,6 +142,32 @@ MODERATION_DRY_RUN=true go run ./cmd/server
 ```
 
 审核统计通过 `GET /api/stats` 的 `moderation` 字段暴露（`reviewed` / `adult_removed` / `spam_removed` / `errors` / `pending` / `blocked`）。
+
+### 顺带：标题去广告（`MODERATION_TRIM_TITLES`）
+
+同一次审核请求里让模型多返回一个 `clean` 字段，把标题里的站点横幅、推广域名、
+「地址发布页 / 收藏不迷路」之类的招徕语和上传者广告尾巴删掉。共用同一次调用，
+只多花输出 token，不会多一轮请求。
+
+- **原名不动**：清理后的标题写进 `clean_name` 列，`name` 永远保留原文，随时可回退
+- **搜索不丢结果**：两列都参与匹配，删掉的广告文字照样能搜到；被广告切断的词组
+  反而因为 `clean_name` 变得可搜
+- **只删不改**：模型只许删字符。结果必须是原标题的**子序列**，否则丢弃——这一条
+  校验就挡掉了改写、翻译、重排和凭空捏造；另有长度下限（≥4 字符且不少于原长 25%）
+- **超长标题不动**：标题超过 200 字符时送审的是截断版，模型没看过尾巴，直接跳过
+- **审计**：每条改动都打印 `moderator: trim <hash> "原名" -> "新名"`，
+  计数进 `llm_titles_trimmed`
+
+实测（deepseek-v4-flash）：`www.UIndex.org - `、`【高清剧集网发布 www.BPHDTV.com】`、
+`[TGx]`、`[EZTVx.to]`、`[ WebToolTip.com ]` 都能正确删除；而
+`【推しの子】`（作品名）、`iDOLM@STER`、`[Erai-raws]`、`-FraMeSToR`
+（字幕组／压制组）都会原样保留。
+
+已经审核过的旧记录不会自动重审。要给存量数据补跑一遍（会重新计费）：
+
+```sql
+UPDATE torrents SET reviewed_at = 0;
+```
 
 ## 部署
 

--- a/env.example
+++ b/env.example
@@ -19,6 +19,10 @@ MODERATION_BATCH_SIZE=50
 MODERATION_MAX_BATCHES=40
 # Set true to log what would be deleted without deleting anything.
 MODERATION_DRY_RUN=false
+# Strip site banners, promo URLs and uploader ad tags from titles during the
+# same hourly pass — one LLM call does both, so this costs only output tokens.
+# The raw title is kept and stays searchable; only the displayed name changes.
+MODERATION_TRIM_TITLES=true
 
 # --- Crawling ---
 # These three interact. Numbers below are measured on a 2 vCPU / 4 GB VPS;

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -94,6 +94,8 @@ func main() {
 		"max batches per moderation pass (0 = unlimited)")
 	modDryRun := flag.Bool("moderate-dry-run", envBool("MODERATION_DRY_RUN", false),
 		"log what moderation would delete without deleting it")
+	modTrim := flag.Bool("moderate-trim-titles", envBool("MODERATION_TRIM_TITLES", true),
+		"also strip advertising from torrent titles during the moderation pass")
 	flag.Parse()
 
 	filter.MinTotalSize = *minSize
@@ -195,6 +197,7 @@ func main() {
 				BatchSize:  *modBatch,
 				MaxBatches: *modMaxBatches,
 				DryRun:     *modDryRun,
+				TrimTitles: *modTrim,
 				Logger:     logger,
 			})
 			if err != nil {

--- a/server/internal/moderator/moderator.go
+++ b/server/internal/moderator/moderator.go
@@ -39,6 +39,7 @@ type Config struct {
 	MaxBatches int           // batches per sweep; 0 = unlimited
 	Timeout    time.Duration // per-request timeout
 	DryRun     bool          // classify and log, but delete nothing
+	TrimTitles bool          // also strip advertising from titles
 	Logger     *log.Logger
 	HTTPClient *http.Client // optional; for tests
 }
@@ -56,6 +57,7 @@ type Summary struct {
 	Adult    int
 	Spam     int
 	Deleted  int64
+	Trimmed  int64
 }
 
 // New validates cfg and builds a Moderator.
@@ -90,8 +92,8 @@ func New(st *store.Store, cfg Config) (*Moderator, error) {
 
 // Run sweeps every Interval until ctx is cancelled. It blocks.
 func (m *Moderator) Run(ctx context.Context) {
-	m.cfg.Logger.Printf("moderator: enabled (model=%s interval=%s batch=%d dry-run=%v)",
-		m.cfg.Model, m.cfg.Interval, m.cfg.BatchSize, m.cfg.DryRun)
+	m.cfg.Logger.Printf("moderator: enabled (model=%s interval=%s batch=%d dry-run=%v trim-titles=%v)",
+		m.cfg.Model, m.cfg.Interval, m.cfg.BatchSize, m.cfg.DryRun, m.cfg.TrimTitles)
 	t := time.NewTicker(m.cfg.Interval)
 	defer t.Stop()
 	for {
@@ -109,8 +111,8 @@ func (m *Moderator) Run(ctx context.Context) {
 				continue
 			}
 			if s.Reviewed > 0 {
-				m.cfg.Logger.Printf("moderator: reviewed=%d adult=%d spam=%d deleted=%d",
-					s.Reviewed, s.Adult, s.Spam, s.Deleted)
+				m.cfg.Logger.Printf("moderator: reviewed=%d adult=%d spam=%d deleted=%d trimmed=%d",
+					s.Reviewed, s.Adult, s.Spam, s.Deleted, s.Trimmed)
 			}
 		}
 	}
@@ -133,6 +135,7 @@ func (m *Moderator) SweepOnce(ctx context.Context) (Summary, error) {
 		total.Adult += s.Adult
 		total.Spam += s.Spam
 		total.Deleted += s.Deleted
+		total.Trimmed += s.Trimmed
 		if err != nil {
 			return total, err
 		}
@@ -143,22 +146,38 @@ func (m *Moderator) SweepOnce(ctx context.Context) (Summary, error) {
 // reviewBatch classifies one batch and applies the verdicts.
 func (m *Moderator) reviewBatch(ctx context.Context, cands []store.Candidate) (Summary, error) {
 	var s Summary
-	labels, err := m.classify(ctx, cands)
+	verdicts, err := m.classify(ctx, cands)
 	if err != nil {
 		return s, err
 	}
 
 	now := time.Now().Unix()
 	var adultH, adultN, spamH, spamN []string
+	trims := map[string]string{}
 	for i, c := range cands {
-		switch labels[i] {
+		switch verdicts[i].label {
 		case labelAdult:
 			adultH, adultN = append(adultH, c.InfoHash), append(adultN, c.Name)
 		case labelSpam:
 			spamH, spamN = append(spamH, c.InfoHash), append(spamN, c.Name)
+		default:
+			// Only worth trimming titles that survive moderation.
+			if v := verdicts[i].clean; v != "" {
+				trims[c.InfoHash] = v
+			}
 		}
 	}
 	s.Reviewed, s.Adult, s.Spam = len(cands), len(adultH), len(spamH)
+
+	// Trims are logged before/after either way — that log is the audit trail
+	// for what the model rewrote.
+	raw := make(map[string]string, len(cands))
+	for _, c := range cands {
+		raw[c.InfoHash] = c.Name
+	}
+	for h, clean := range trims {
+		m.cfg.Logger.Printf("moderator: trim %s %q -> %q", h, raw[h], clean)
+	}
 
 	if m.cfg.DryRun {
 		for i, h := range adultH {
@@ -168,6 +187,12 @@ func (m *Moderator) reviewBatch(ctx context.Context, cands []store.Candidate) (S
 			m.cfg.Logger.Printf("moderator: [dry-run] would remove spam %s %q", h, spamN[i])
 		}
 	} else {
+		n, err := m.st.SetCleanNames(trims)
+		if err != nil {
+			return s, fmt.Errorf("set clean names: %w", err)
+		}
+		s.Trimmed = n
+		m.st.IncrStat("llm_titles_trimmed", n)
 		for _, g := range []struct {
 			hashes, names []string
 			reason, stat  string
@@ -202,8 +227,23 @@ func (m *Moderator) reviewBatch(ctx context.Context, cands []store.Candidate) (S
 	return s, nil
 }
 
-const systemPrompt = `You are a content-moderation classifier for a BitTorrent metadata index.
-You receive a numbered list of torrent listings. Assign each exactly one label:
+// systemPromptFor builds the instructions. The title-trimming half is left out
+// entirely when the feature is off, so it costs no tokens.
+func systemPromptFor(trim bool) string {
+	if trim {
+		return promptHead + "For each one, assign a label and return a cleaned-up title.\n" +
+			promptLabel + promptClean + promptTailTrim
+	}
+	return promptHead + "Assign each one a label.\n" + promptLabel + promptTail
+}
+
+const promptHead = `You are a content-moderation classifier for a BitTorrent metadata index.
+You receive a JSON array of torrent listings, each with "i" (its number),
+"title", "size" and "files". Judge only by "title"; "size" and "files" are
+context. `
+
+const promptLabel = `
+LABEL — assign each listing exactly one:
 
 - "adult": pornography or sexually explicit material (including JAV, hentai,
   camgirl/webcam rips, escort or sex-work advertising).
@@ -220,17 +260,64 @@ Rules:
 - Sex education, documentaries and mainstream films with sexual themes are "ok";
   reserve "adult" for material whose purpose is explicit sexual content.
 - When genuinely unsure, answer "ok".
+`
 
+const promptClean = `
+CLEAN — the same title with advertising removed. Copy the title and DELETE the
+promotional spans. Never reword, translate, reorder, re-space or re-punctuate
+anything you keep: the result must be the original title with characters removed
+and nothing else.
+
+Delete:
+- Site and forum banners, in any bracket style: 【高清剧集网发布 www.xxx.com】,
+  [ www.UsaBit.com ] -, (www.xxx.net), www.xxx.com@, 【xxx论坛】.
+- Bare URLs, domains and invite codes that advertise a site.
+- Solicitations: 地址发布页, 收藏不迷路, 关注我们, 更多资源请访问, 最新地址,
+  免费下载, "visit", "download more at", QQ/WeChat/Telegram handles and numbers.
+- Uploader ad tags appended to the end: [TGx], [EZTVx.to], -RARBG.com, [rartv].
+
+Keep everything that describes the release, even if it looks like noise:
+- Title, year, season/episode, resolution, source, codec, bit depth, HDR.
+- Audio format and channels, language and subtitle tags, file extension.
+- Release-group and fansub tags: -FraMeSToR, [Erai-raws], [ReinForce], -NTb.
+  These identify the release, they are not advertising.
+
+If a title has no advertising, return it unchanged. Never return an empty
+string, and never delete so much that the work is no longer identifiable.
+"clean" holds the title text ONLY — never append the size or the file count.
+`
+
+const promptTailTrim = `
+Respond with JSON only, no prose, in exactly this shape:
+{"verdicts":[{"i":1,"label":"ok","clean":"cleaned title"},{"i":2,"label":"adult","clean":"cleaned title"}]}
+Include exactly one entry for every input number.`
+
+const promptTail = `
 Respond with JSON only, no prose, in exactly this shape:
 {"verdicts":[{"i":1,"label":"ok"},{"i":2,"label":"adult"}]}
 Include exactly one entry for every input number.`
 
-// classify returns a label per candidate, aligned by index. Entries the model
+// verdict is the model's answer for one candidate. clean is empty unless the
+// model proposed a trimmed title that passed validation.
+type verdict struct {
+	label string
+	clean string
+}
+
+// classify returns a verdict per candidate, aligned by index. Entries the model
 // omits or labels unknown default to "ok" (fail-open: never delete on doubt).
-func (m *Moderator) classify(ctx context.Context, cands []store.Candidate) ([]string, error) {
-	var b strings.Builder
+func (m *Moderator) classify(ctx context.Context, cands []store.Candidate) ([]verdict, error) {
+	// The listing goes over as JSON so "title" is unambiguously delimited. With
+	// a "<title> [1.2GB, 3 files]" line the model intermittently copied the
+	// size suffix into the cleaned title, which validation then rejected.
+	items := make([]promptItem, len(cands))
 	for i, c := range cands {
-		fmt.Fprintf(&b, "%d. %s [%s, %d files]\n", i+1, sanitize(c.Name), humanSize(c.TotalSize), c.FileCount)
+		name, _ := promptName(c.Name)
+		items[i] = promptItem{I: i + 1, Title: name, Size: humanSize(c.TotalSize), Files: c.FileCount}
+	}
+	listing, err := json.Marshal(items)
+	if err != nil {
+		return nil, err
 	}
 
 	reqBody, err := json.Marshal(chatRequest{
@@ -238,8 +325,8 @@ func (m *Moderator) classify(ctx context.Context, cands []store.Candidate) ([]st
 		Temperature:    0,
 		ResponseFormat: &responseFormat{Type: "json_object"},
 		Messages: []chatMessage{
-			{Role: "system", Content: systemPrompt},
-			{Role: "user", Content: b.String()},
+			{Role: "system", Content: systemPromptFor(m.cfg.TrimTitles)},
+			{Role: "user", Content: string(listing)},
 		},
 	})
 	if err != nil {
@@ -251,9 +338,9 @@ func (m *Moderator) classify(ctx context.Context, cands []store.Candidate) ([]st
 		return nil, err
 	}
 
-	labels := make([]string, len(cands))
-	for i := range labels {
-		labels[i] = labelOK
+	out := make([]verdict, len(cands))
+	for i := range out {
+		out[i] = verdict{label: labelOK}
 	}
 	var parsed verdictResponse
 	if err := json.Unmarshal([]byte(stripFences(raw)), &parsed); err != nil {
@@ -265,12 +352,15 @@ func (m *Moderator) classify(ctx context.Context, cands []store.Candidate) ([]st
 		}
 		switch strings.ToLower(strings.TrimSpace(v.Label)) {
 		case labelAdult:
-			labels[v.I-1] = labelAdult
+			out[v.I-1].label = labelAdult
 		case labelSpam:
-			labels[v.I-1] = labelSpam
+			out[v.I-1].label = labelSpam
+		}
+		if m.cfg.TrimTitles {
+			out[v.I-1].clean = cleanTitle(cands[v.I-1].Name, v.Clean)
 		}
 	}
-	return labels, nil
+	return out, nil
 }
 
 // post sends one chat completion request, retrying on 429 and 5xx.
@@ -340,19 +430,85 @@ func stripFences(s string) string {
 	return strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(s), "```"))
 }
 
-// sanitize keeps a title on one line and bounded in length so it cannot break
-// the numbered list or blow up the prompt.
+// promptNameCap bounds how much of a title reaches the model, so one absurd
+// name cannot blow up the prompt.
+const promptNameCap = 200
+
+// sanitize keeps a title on one line so it cannot break the numbered list.
 func sanitize(s string) string {
-	s = strings.Map(func(r rune) rune {
+	return strings.Map(func(r rune) rune {
 		if r == '\n' || r == '\r' || r == '\t' {
 			return ' '
 		}
 		return r
 	}, s)
-	if r := []rune(s); len(r) > 200 {
-		s = string(r[:200]) + "…"
+}
+
+// promptName renders a title for the prompt, reporting whether it had to be cut
+// short. A truncated title must never be trimmed: the model never saw the tail,
+// so applying its answer would silently delete the rest of the name.
+func promptName(s string) (text string, truncated bool) {
+	s = sanitize(s)
+	if r := []rune(s); len(r) > promptNameCap {
+		return string(r[:promptNameCap]) + "…", true
 	}
-	return s
+	return s, false
+}
+
+// Guards against a model that rewrites instead of trimming. A cleaned title
+// must keep at least this many runes, and this share of the original.
+const (
+	minCleanRunes = 4
+	minCleanRatio = 0.25
+)
+
+// cleanTitle validates a model-proposed title against the original and returns
+// the value to store, or "" when the proposal must be ignored.
+//
+// The model is told to only delete characters, so the proposal must remain a
+// subsequence of the original. That single check rejects rewrites,
+// translations, re-spacing and outright hallucination — anything that invents a
+// rune the original did not have, in the order it had it.
+func cleanTitle(raw, proposed string) string {
+	full, truncated := promptName(raw)
+	if truncated {
+		return ""
+	}
+	proposed = strings.Trim(collapseSpaces(proposed), " \t-_|")
+	if proposed == "" || proposed == full || proposed == collapseSpaces(full) {
+		return ""
+	}
+	rp, rf := []rune(proposed), []rune(full)
+	if len(rp) > len(rf) ||
+		len(rp) < minCleanRunes ||
+		float64(len(rp)) < minCleanRatio*float64(len(rf)) {
+		return ""
+	}
+	if !isSubsequence(rp, rf) {
+		return ""
+	}
+	return proposed
+}
+
+// isSubsequence reports whether sub can be obtained from of by deleting runes.
+func isSubsequence(sub, of []rune) bool {
+	j := 0
+	for _, c := range sub {
+		for j < len(of) && of[j] != c {
+			j++
+		}
+		if j == len(of) {
+			return false
+		}
+		j++
+	}
+	return true
+}
+
+// collapseSpaces squeezes runs of whitespace into a single space, tidying the
+// gap left where an advertising span was cut out.
+func collapseSpaces(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }
 
 func humanSize(n int64) string {
@@ -390,9 +546,18 @@ type chatResponse struct {
 	} `json:"choices"`
 }
 
+// promptItem is one listing as presented to the model.
+type promptItem struct {
+	I     int    `json:"i"`
+	Title string `json:"title"`
+	Size  string `json:"size"`
+	Files int    `json:"files"`
+}
+
 type verdictResponse struct {
 	Verdicts []struct {
 		I     int    `json:"i"`
 		Label string `json:"label"`
+		Clean string `json:"clean"`
 	} `json:"verdicts"`
 }

--- a/server/internal/moderator/moderator_test.go
+++ b/server/internal/moderator/moderator_test.go
@@ -60,9 +60,13 @@ func fakeAPI(t *testing.T, label func(title string) string, calls *int32) *httpt
 			I     int    `json:"i"`
 			Label string `json:"label"`
 		}
+		var items []promptItem
+		if err := json.Unmarshal([]byte(req.Messages[1].Content), &items); err != nil {
+			t.Fatalf("listing is not JSON: %v (%q)", err, req.Messages[1].Content)
+		}
 		var out []v
-		for i, line := range strings.Split(strings.TrimSpace(req.Messages[1].Content), "\n") {
-			out = append(out, v{I: i + 1, Label: label(line)})
+		for _, it := range items {
+			out = append(out, v{I: it.I, Label: label(it.Title)})
 		}
 		content, _ := json.Marshal(map[string]any{"verdicts": out})
 		json.NewEncoder(w).Encode(chatResponse{Choices: []struct {

--- a/server/internal/moderator/trim_test.go
+++ b/server/internal/moderator/trim_test.go
@@ -1,0 +1,299 @@
+package moderator
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCleanTitleAcceptsDeletionOnly(t *testing.T) {
+	tests := []struct {
+		name, raw, proposed, want string
+	}{
+		{
+			name:     "leading site banner",
+			raw:      "【高清剧集网发布 www.abc.com】三体 第二季 全集[国语中字]",
+			proposed: "三体 第二季 全集[国语中字]",
+			want:     "三体 第二季 全集[国语中字]",
+		},
+		{
+			name:     "bracketed domain prefix",
+			raw:      "[ www.UsaBit.com ] - The Jungle Book 1967 720p BRRip x264-PLAYNOW.mp4",
+			proposed: "The Jungle Book 1967 720p BRRip x264-PLAYNOW.mp4",
+			want:     "The Jungle Book 1967 720p BRRip x264-PLAYNOW.mp4",
+		},
+		{
+			name:     "trailing uploader tag",
+			raw:      "The Simpsons S32E18 1080p DSNP WEB-DL DDP5 1 H 264-playWEB[TGx]",
+			proposed: "The Simpsons S32E18 1080p DSNP WEB-DL DDP5 1 H 264-playWEB",
+			want:     "The Simpsons S32E18 1080p DSNP WEB-DL DDP5 1 H 264-playWEB",
+		},
+		{
+			name:     "gap left by an excised span is squeezed",
+			raw:      "Movie 2003 www.spam.net 1080p",
+			proposed: "Movie 2003  1080p",
+			want:     "Movie 2003 1080p",
+		},
+		{
+			name:     "stray separator left behind is trimmed",
+			raw:      "[ www.UsaBit.com ] - The Jungle Book",
+			proposed: "- The Jungle Book",
+			want:     "The Jungle Book",
+		},
+		// Rejections: anything that is not pure deletion, or cuts too deep.
+		{
+			name:     "unchanged title stores nothing",
+			raw:      "Ubuntu 24.04 ISO",
+			proposed: "Ubuntu 24.04 ISO",
+			want:     "",
+		},
+		{
+			name:     "reworded title is rejected",
+			raw:      "Dune Part Two 2024 2160p",
+			proposed: "Dune: Part 2 (2024) 4K",
+			want:     "",
+		},
+		{
+			name:     "translated title is rejected",
+			raw:      "三体 第二季",
+			proposed: "Three Body Season 2",
+			want:     "",
+		},
+		{
+			name:     "reordered title is rejected",
+			raw:      "Alpha Beta Gamma",
+			proposed: "Gamma Alpha",
+			want:     "",
+		},
+		{
+			name:     "hallucinated addition is rejected",
+			raw:      "Movie 2003 1080p",
+			proposed: "Movie 2003 1080p BluRay",
+			want:     "",
+		},
+		{
+			name:     "empty proposal is rejected",
+			raw:      "Movie 2003 1080p",
+			proposed: "   ",
+			want:     "",
+		},
+		{
+			name:     "over-trimming below the ratio floor is rejected",
+			raw:      "Some Quite Long Movie Title 2003 1080p BluRay x264",
+			proposed: "Some",
+			want:     "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cleanTitle(tc.raw, tc.proposed); got != tc.want {
+				t.Errorf("cleanTitle(%q, %q) = %q, want %q", tc.raw, tc.proposed, got, tc.want)
+			}
+		})
+	}
+}
+
+// A title too long for the prompt is shown truncated, so the model never sees
+// its tail. Applying the answer would silently delete the rest of the name.
+func TestCleanTitleSkipsTruncatedNames(t *testing.T) {
+	raw := strings.Repeat("A", promptNameCap+50)
+	if got := cleanTitle(raw, strings.Repeat("A", promptNameCap)); got != "" {
+		t.Errorf("cleanTitle on truncated name = %q, want empty", got)
+	}
+}
+
+func TestIsSubsequence(t *testing.T) {
+	tests := []struct {
+		sub, of string
+		want    bool
+	}{
+		{"abc", "abc", true},
+		{"ac", "abc", true},
+		{"", "abc", true},
+		{"abc", "ab", false},
+		{"ba", "abc", false},
+		{"三体", "【广告】三体 第二季", true},
+	}
+	for _, tc := range tests {
+		if got := isSubsequence([]rune(tc.sub), []rune(tc.of)); got != tc.want {
+			t.Errorf("isSubsequence(%q, %q) = %v, want %v", tc.sub, tc.of, got, tc.want)
+		}
+	}
+}
+
+func TestSystemPromptOmitsTrimSectionWhenDisabled(t *testing.T) {
+	on, off := systemPromptFor(true), systemPromptFor(false)
+	if !strings.Contains(on, "CLEAN") || !strings.Contains(on, `"clean"`) {
+		t.Error("trim-enabled prompt is missing the CLEAN section")
+	}
+	if strings.Contains(off, "CLEAN") || strings.Contains(off, `"clean"`) {
+		t.Error("trim-disabled prompt still asks for cleaned titles")
+	}
+	for _, p := range []string{on, off} {
+		if !strings.Contains(p, `"adult"`) || !strings.Contains(p, `"spam"`) {
+			t.Error("prompt lost its moderation labels")
+		}
+	}
+}
+
+// trimAPI serves an OpenAI-compatible endpoint that labels everything "ok" and
+// returns clean(title) as the trimmed title.
+func trimAPI(t *testing.T, clean func(line string) string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req chatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatal(err)
+		}
+		type v struct {
+			I     int    `json:"i"`
+			Label string `json:"label"`
+			Clean string `json:"clean"`
+		}
+		var items []promptItem
+		if err := json.Unmarshal([]byte(req.Messages[1].Content), &items); err != nil {
+			t.Fatalf("listing is not JSON: %v (%q)", err, req.Messages[1].Content)
+		}
+		var out []v
+		for _, it := range items {
+			out = append(out, v{I: it.I, Label: "ok", Clean: clean(it.Title)})
+		}
+		content, _ := json.Marshal(map[string]any{"verdicts": out})
+		json.NewEncoder(w).Encode(chatResponse{Choices: []struct {
+			Message chatMessage `json:"message"`
+		}{{Message: chatMessage{Content: string(content)}}}})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestSweepTrimsAdvertisingFromTitles(t *testing.T) {
+	st := newStore(t)
+	const adTitle = "【发布页 www.spam.net】Blue Bloods S14E03 1080p AMZN WEB-DL"
+	seed(t, st, adTitle, "Ubuntu 24.04 ISO")
+
+	srv := trimAPI(t, func(title string) string {
+		return strings.TrimPrefix(title, "【发布页 www.spam.net】")
+	})
+	m := newMod(t, st, srv.URL, func(c *Config) { c.TrimTitles = true })
+
+	s, err := m.SweepOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Trimmed != 1 {
+		t.Errorf("Trimmed = %d, want 1", s.Trimmed)
+	}
+
+	items, _, err := st.Search("", 1, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := map[string]bool{}
+	for _, it := range items {
+		names[it.Name] = true
+	}
+	if !names["Blue Bloods S14E03 1080p AMZN WEB-DL"] {
+		t.Errorf("search did not return the trimmed title, got %v", names)
+	}
+	if names[adTitle] {
+		t.Error("search still returns the raw advertising title")
+	}
+	// The untouched title must survive verbatim.
+	if !names["Ubuntu 24.04 ISO"] {
+		t.Errorf("clean title was altered, got %v", names)
+	}
+}
+
+// The raw title stays searchable, so trimming can never hide a result.
+func TestTrimmedTorrentIsStillFoundByRawText(t *testing.T) {
+	st := newStore(t)
+	seed(t, st, "【发布页 www.spam.net】Blue Bloods S14E03 1080p")
+
+	srv := trimAPI(t, func(title string) string {
+		return strings.TrimPrefix(title, "【发布页 www.spam.net】")
+	})
+	m := newMod(t, st, srv.URL, func(c *Config) { c.TrimTitles = true })
+	if _, err := m.SweepOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, q := range []string{"spam.net", "Blue Bloods"} {
+		items, total, err := st.Search(q, 1, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 1 || len(items) != 1 {
+			t.Errorf("Search(%q) total = %d, want 1", q, total)
+		}
+	}
+}
+
+func TestTrimDisabledLeavesTitlesAlone(t *testing.T) {
+	st := newStore(t)
+	const adTitle = "【发布页 www.spam.net】Blue Bloods S14E03 1080p"
+	seed(t, st, adTitle)
+
+	srv := trimAPI(t, func(line string) string { return "Blue Bloods S14E03 1080p" })
+	m := newMod(t, st, srv.URL, func(c *Config) { c.TrimTitles = false })
+	s, err := m.SweepOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Trimmed != 0 {
+		t.Errorf("Trimmed = %d, want 0", s.Trimmed)
+	}
+	items, _, err := st.Search("", 1, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if items[0].Name != adTitle {
+		t.Errorf("Name = %q, want the raw title %q", items[0].Name, adTitle)
+	}
+}
+
+func TestDryRunTrimsNothing(t *testing.T) {
+	st := newStore(t)
+	const adTitle = "【发布页 www.spam.net】Blue Bloods S14E03 1080p"
+	seed(t, st, adTitle)
+
+	srv := trimAPI(t, func(line string) string { return "Blue Bloods S14E03 1080p" })
+	m := newMod(t, st, srv.URL, func(c *Config) { c.TrimTitles, c.DryRun = true, true })
+	if _, err := m.SweepOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	items, _, err := st.Search("", 1, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if items[0].Name != adTitle {
+		t.Errorf("dry run modified the title: got %q", items[0].Name)
+	}
+}
+
+// A model that rewrites rather than deletes must not reach the database.
+func TestSweepRejectsRewrittenTitles(t *testing.T) {
+	st := newStore(t)
+	const raw = "Dune Part Two 2024 2160p"
+	seed(t, st, raw)
+
+	srv := trimAPI(t, func(line string) string { return "Dune: Part 2 (2024) 4K" })
+	m := newMod(t, st, srv.URL, func(c *Config) { c.TrimTitles = true })
+	s, err := m.SweepOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Trimmed != 0 {
+		t.Errorf("Trimmed = %d, want 0", s.Trimmed)
+	}
+	items, _, err := st.Search("", 1, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if items[0].Name != raw {
+		t.Errorf("Name = %q, want %q", items[0].Name, raw)
+	}
+}

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -56,7 +56,11 @@ CREATE TABLE IF NOT EXISTS torrents (
 	file_count  INTEGER NOT NULL,
 	files_json  TEXT NOT NULL,
 	created_at  INTEGER NOT NULL,
-	reviewed_at INTEGER NOT NULL DEFAULT 0
+	reviewed_at INTEGER NOT NULL DEFAULT 0,
+	-- Title with promotional junk stripped by the moderation pass. Empty means
+	-- "not trimmed"; name always keeps the raw title so trimming is reversible
+	-- and search still matches text that only appears in the original.
+	clean_name  TEXT NOT NULL DEFAULT ''
 );
 CREATE TABLE IF NOT EXISTS stats (
 	key   TEXT PRIMARY KEY,
@@ -79,10 +83,15 @@ CREATE TABLE IF NOT EXISTS blocked (
 	// case on an already-migrated database. This must run before anything
 	// that references reviewed_at — on a pre-migration database the column
 	// does not exist yet and those statements would fail.
-	if _, err := db.Exec(`ALTER TABLE torrents ADD COLUMN reviewed_at INTEGER NOT NULL DEFAULT 0`); err != nil &&
-		!strings.Contains(err.Error(), "duplicate column name") {
-		db.Close()
-		return nil, fmt.Errorf("migrate reviewed_at: %w", err)
+	for _, m := range []struct{ name, stmt string }{
+		{"reviewed_at", `ALTER TABLE torrents ADD COLUMN reviewed_at INTEGER NOT NULL DEFAULT 0`},
+		{"clean_name", `ALTER TABLE torrents ADD COLUMN clean_name TEXT NOT NULL DEFAULT ''`},
+	} {
+		if _, err := db.Exec(m.stmt); err != nil &&
+			!strings.Contains(err.Error(), "duplicate column name") {
+			db.Close()
+			return nil, fmt.Errorf("migrate %s: %w", m.name, err)
+		}
 	}
 	// Partial index: only unreviewed rows are indexed, so it stays tiny and the
 	// moderation sweep never scans the full table. Created after the migration
@@ -122,15 +131,18 @@ func (s *Store) Search(query string, page, pageSize int) (items []Torrent, total
 	if len(keywords) > 0 {
 		var conds []string
 		for _, kw := range keywords {
-			conds = append(conds, "name LIKE ? ESCAPE '\\'")
-			args = append(args, "%"+escapeLike(kw)+"%")
+			// Match either title: the raw one so trimming can never hide a
+			// result, and the cleaned one so a phrase that only reads
+			// contiguously once the ad text is gone still matches.
+			conds = append(conds, "(name LIKE ? ESCAPE '\\' OR clean_name LIKE ? ESCAPE '\\')")
+			args = append(args, "%"+escapeLike(kw)+"%", "%"+escapeLike(kw)+"%")
 		}
 		where = " WHERE " + strings.Join(conds, " AND ")
 	}
 	if err = s.db.QueryRow(`SELECT COUNT(*) FROM torrents`+where, args...).Scan(&total); err != nil {
 		return nil, 0, err
 	}
-	q := `SELECT info_hash, name, total_size, file_count, files_json, created_at
+	q := `SELECT info_hash, IIF(clean_name <> '', clean_name, name), total_size, file_count, files_json, created_at
 	      FROM torrents` + where + ` ORDER BY created_at DESC LIMIT ? OFFSET ?`
 	rows, err := s.db.Query(q, append(args, pageSize, (page-1)*pageSize)...)
 	if err != nil {
@@ -188,6 +200,40 @@ func (s *Store) MarkReviewed(hashes []string, ts int64) error {
 	_, err := s.db.Exec(
 		`UPDATE torrents SET reviewed_at = ? WHERE info_hash IN (`+placeholders(len(hashes))+`)`, args...)
 	return err
+}
+
+// SetCleanNames records trimmed titles. clean is keyed by info hash and holds
+// the title with promotional text removed; the raw name column is left alone.
+// Returns the number of rows updated.
+func (s *Store) SetCleanNames(clean map[string]string) (int64, error) {
+	if len(clean) == 0 {
+		return 0, nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	up, err := tx.Prepare(`UPDATE torrents SET clean_name = ? WHERE info_hash = ?`)
+	if err != nil {
+		return 0, err
+	}
+	defer up.Close()
+
+	var n int64
+	for hash, name := range clean {
+		res, err := up.Exec(name, hash)
+		if err != nil {
+			return 0, err
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return 0, err
+		}
+		n += affected
+	}
+	return n, tx.Commit()
 }
 
 // Block deletes the named torrents and records them as rejected so the

--- a/server/internal/store/store_test.go
+++ b/server/internal/store/store_test.go
@@ -179,3 +179,47 @@ func TestOpenMigratesPreModerationDB(t *testing.T) {
 	}
 	s2.Close()
 }
+
+func TestSetCleanNamesReplacesDisplayNameOnly(t *testing.T) {
+	s := openTest(t)
+	const raw = "【发布页 www.spam.net】Blue Bloods S14E03 1080p"
+	if err := s.Upsert(Torrent{InfoHash: "aa", Name: raw, TotalSize: 1 << 30, FileCount: 1, CreatedAt: 100}); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := s.SetCleanNames(map[string]string{"aa": "Blue Bloods S14E03 1080p"})
+	if err != nil || n != 1 {
+		t.Fatalf("SetCleanNames = %d, %v; want 1, nil", n, err)
+	}
+
+	// Search returns the cleaned title...
+	items, _, err := s.Search("", 1, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if items[0].Name != "Blue Bloods S14E03 1080p" {
+		t.Errorf("Name = %q, want the cleaned title", items[0].Name)
+	}
+
+	// ...but the raw title is preserved in the row and still matches.
+	var stored string
+	if err := s.db.QueryRow(`SELECT name FROM torrents WHERE info_hash='aa'`).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored != raw {
+		t.Errorf("stored name = %q, want the raw title %q", stored, raw)
+	}
+	for _, q := range []string{"spam.net", "Blue Bloods", "Bloods 1080p"} {
+		if _, total, err := s.Search(q, 1, 10); err != nil || total != 1 {
+			t.Errorf("Search(%q) total = %d err = %v, want 1", q, total, err)
+		}
+	}
+}
+
+func TestSetCleanNamesEmptyMapIsNoOp(t *testing.T) {
+	s := openTest(t)
+	n, err := s.SetCleanNames(nil)
+	if err != nil || n != 0 {
+		t.Fatalf("SetCleanNames(nil) = %d, %v; want 0, nil", n, err)
+	}
+}


### PR DESCRIPTION
The index is full of titles wearing a billboard: `www.UIndex.org    -    `, `【高清剧集网发布 www.BPHDTV.com】`, `[TGx]`, `[ WebToolTip.com ]`.

## Approach

The hourly moderation pass already sends every unreviewed title to the model, so rather than add a second pass this extends the **same call** to return a `clean` field alongside the label — no extra request, only output tokens. The whole prompt section is omitted when `MODERATION_TRIM_TITLES=false`, so disabling it costs nothing.

**The raw title is never destroyed.** Cleaned titles go into a new `clean_name` column; `name` keeps the original. `Search` displays `clean_name` when present and matches *both* columns — so trimming can never hide a result, and a phrase the ad text used to interrupt (`Blue Bloods 1080p` split by a banner) becomes searchable for the first time.

## The guardrail

Letting a model rewrite user-visible text needs a hard boundary, so a proposal is stored only if it is a **subsequence of the original** — pure deletion, nothing else. That single check rejects rewrites, translations, reordering and hallucination. Plus length floors (>= 4 runes, >= 25% of the original), and titles longer than the 200-char prompt cap are skipped outright: the model only saw a prefix, so applying its answer would silently delete the tail.

Every change is logged `moderator: trim <hash> "old" -> "new"` and counted in `llm_titles_trimmed`.

## Verification

Tested the real prompt against **deepseek-v4-flash** using titles pulled from the production database.

Trimmed correctly (7/7): `www.UIndex.org    -    ` · `【8i2.fit】` · `【高清剧集网发布 www.BPHDTV.com】` · `[TGx]` · `[EZTVx.to]` · `[ www.TorrentDay.com ] - ` · `[ WebToolTip.com ]`

Traps preserved (6/6): **【推しの子】** (a work title in the same bracket style as a banner), **iDOLM@STER** (an `@` inside a real name), `[Erai-raws]`, `[Feranki1980]`, `-FraMeSToR`, and a plain `debian-…​.iso`.

That run also caught a real bug: with the old `<title> [1.2GB, 3 files]` line format the model intermittently copied the size suffix into the cleaned title, which validation then rejected — meaning nothing would ever be trimmed. The listing is now sent as JSON so `title` is unambiguously delimited.

19 new unit tests cover the validator (including every rejection mode), the store column and the end-to-end sweep. `go vet`, `gofmt`, the full Go suite and the web build all pass.

## Note on existing rows

All ~37k indexed rows are already stamped `reviewed_at != 0`, so the pass skips them and they keep their current titles — and `www.UIndex.org` is on a large share of them. A backfill is one statement:

```sql
UPDATE torrents SET reviewed_at = 0;
```

but that re-classifies the entire index (~750 batches, ~19h at the current rate cap) and costs a full re-run, so it is documented in the README rather than done automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)