### PR TITLE
server: default to a free OpenRouter model for moderation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
       ▼
 ┌──────────────────┐   命中    ┌────────────────────┐
 │ LLM 审核          │─────────►│ 删除 + 写入 blocked │
-│ (DeepSeek V4 Flash)│          └────────────────────┘
+│ (OpenRouter 免费模型)│         └────────────────────┘
 └──────────────────┘
 ```
 
@@ -90,12 +90,12 @@ LLM 审核相关（见下文「LLM 二次审核」）：
 | 变量 | 默认 | 说明 |
 | --- | --- | --- |
 | `OPENAI_API_KEY` | 无 | **必填**，未设置则审核不启动 |
-| `OPENAI_BASE_URL` | `https://api.deepseek.com/v1` | 任意 OpenAI 兼容端点 |
-| `OPENAI_MODEL` | `deepseek-v4-flash` | 审核模型 |
+| `OPENAI_BASE_URL` | `https://openrouter.ai/api/v1` | 任意 OpenAI 兼容端点 |
+| `OPENAI_MODEL` | `inclusionai/ling-3.0-flash:free` | 审核模型（`:free` 后缀为 OpenRouter 免费模型） |
 | `MODERATION_ENABLED` | `true` | 总开关 |
 | `MODERATION_INTERVAL` | `1h` | 审核周期 |
-| `MODERATION_BATCH_SIZE` | `50` | 每次请求送审的标题数 |
-| `MODERATION_MAX_BATCHES` | `40` | 每轮最多几批（0 = 不限），用于封顶开销 |
+| `MODERATION_BATCH_SIZE` | `100` | 每次请求送审的标题数 |
+| `MODERATION_MAX_BATCHES` | `20` | 每轮最多几批（0 = 不限），用于封顶开销 |
 | `MODERATION_DRY_RUN` | `false` | 只打日志不删除 |
 | `MODERATION_TRIM_TITLES` | `true` | 顺带清理标题里的广告文字 |
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ LLM 审核相关（见下文「LLM 二次审核」）：
 | --- | --- | --- |
 | `OPENAI_API_KEY` | 无 | **必填**，未设置则审核不启动 |
 | `OPENAI_BASE_URL` | `https://openrouter.ai/api/v1` | 任意 OpenAI 兼容端点 |
-| `OPENAI_MODEL` | `inclusionai/ling-3.0-flash:free` | 审核模型（`:free` 后缀为 OpenRouter 免费模型） |
+| `OPENAI_MODEL` | `nvidia/nemotron-3-super-120b-a12b:free` | 审核模型（`:free` 后缀为 OpenRouter 免费模型） |
 | `MODERATION_ENABLED` | `true` | 总开关 |
 | `MODERATION_INTERVAL` | `1h` | 审核周期 |
 | `MODERATION_BATCH_SIZE` | `100` | 每次请求送审的标题数 |

--- a/env.example
+++ b/env.example
@@ -6,17 +6,26 @@
 # stays off and the static keyword filter still runs.
 OPENAI_API_KEY=
 
-# DeepSeek is the default provider. Any OpenAI-compatible endpoint works:
+# OpenRouter with a free (:free) model is the default provider. Free models
+# cost nothing but are rate-limited per account: 20 req/min, and 1000 req/day
+# only if the account has ever bought >= $10 of credits (50/day otherwise).
+# In OpenRouter settings, the privacy/data policy must allow free endpoints
+# (prompts may be used for training) or requests fail with "no endpoints".
+# Any OpenAI-compatible endpoint works:
+#   DeepSeek     https://api.deepseek.com/v1      + OPENAI_MODEL=deepseek-v4-flash
 #   OpenAI       https://api.openai.com/v1        + OPENAI_MODEL=gpt-4o-mini
-#   OpenRouter   https://openrouter.ai/api/v1     + OPENAI_MODEL=deepseek/deepseek-v4-flash
-OPENAI_BASE_URL=https://api.deepseek.com/v1
-OPENAI_MODEL=deepseek-v4-flash
+OPENAI_BASE_URL=https://openrouter.ai/api/v1
+OPENAI_MODEL=inclusionai/ling-3.0-flash:free
 
 MODERATION_ENABLED=true
 MODERATION_INTERVAL=1h
-MODERATION_BATCH_SIZE=50
-# Batches per pass; caps hourly spend. 40 x 50 = 2000 titles/hour. 0 = unlimited.
-MODERATION_MAX_BATCHES=40
+# 100 titles per request keeps throughput at 2000 titles/hour while halving
+# request count vs 50x40: 20 x 24 = 480 req/day, well under OpenRouter's
+# 1000 req/day free-model cap (which counts retries and any other free-model
+# use on the account).
+MODERATION_BATCH_SIZE=100
+# Batches per pass; caps hourly spend. 20 x 100 = 2000 titles/hour. 0 = unlimited.
+MODERATION_MAX_BATCHES=20
 # Set true to log what would be deleted without deleting anything.
 MODERATION_DRY_RUN=false
 # Strip site banners, promo URLs and uploader ad tags from titles during the

--- a/env.example
+++ b/env.example
@@ -15,7 +15,7 @@ OPENAI_API_KEY=
 #   DeepSeek     https://api.deepseek.com/v1      + OPENAI_MODEL=deepseek-v4-flash
 #   OpenAI       https://api.openai.com/v1        + OPENAI_MODEL=gpt-4o-mini
 OPENAI_BASE_URL=https://openrouter.ai/api/v1
-OPENAI_MODEL=inclusionai/ling-3.0-flash:free
+OPENAI_MODEL=nvidia/nemotron-3-super-120b-a12b:free
 
 MODERATION_ENABLED=true
 MODERATION_INTERVAL=1h

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -84,7 +84,7 @@ func main() {
 		"enable the periodic LLM moderation pass (requires OPENAI_API_KEY)")
 	modBaseURL := flag.String("moderate-base-url", envDefault("OPENAI_BASE_URL", "https://openrouter.ai/api/v1"),
 		"OpenAI-compatible API base URL")
-	modModel := flag.String("moderate-model", envDefault("OPENAI_MODEL", "inclusionai/ling-3.0-flash:free"),
+	modModel := flag.String("moderate-model", envDefault("OPENAI_MODEL", "nvidia/nemotron-3-super-120b-a12b:free"),
 		"chat model used for moderation")
 	modInterval := flag.Duration("moderate-interval", envDuration("MODERATION_INTERVAL", time.Hour),
 		"how often to run the moderation pass")

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -82,15 +82,15 @@ func main() {
 	// LLM moderation pass.
 	modEnabled := flag.Bool("moderate", envBool("MODERATION_ENABLED", true),
 		"enable the periodic LLM moderation pass (requires OPENAI_API_KEY)")
-	modBaseURL := flag.String("moderate-base-url", envDefault("OPENAI_BASE_URL", "https://api.deepseek.com/v1"),
+	modBaseURL := flag.String("moderate-base-url", envDefault("OPENAI_BASE_URL", "https://openrouter.ai/api/v1"),
 		"OpenAI-compatible API base URL")
-	modModel := flag.String("moderate-model", envDefault("OPENAI_MODEL", "deepseek-v4-flash"),
+	modModel := flag.String("moderate-model", envDefault("OPENAI_MODEL", "inclusionai/ling-3.0-flash:free"),
 		"chat model used for moderation")
 	modInterval := flag.Duration("moderate-interval", envDuration("MODERATION_INTERVAL", time.Hour),
 		"how often to run the moderation pass")
-	modBatch := flag.Int("moderate-batch", envInt("MODERATION_BATCH_SIZE", 50),
+	modBatch := flag.Int("moderate-batch", envInt("MODERATION_BATCH_SIZE", 100),
 		"torrent titles per moderation request")
-	modMaxBatches := flag.Int("moderate-max-batches", envInt("MODERATION_MAX_BATCHES", 40),
+	modMaxBatches := flag.Int("moderate-max-batches", envInt("MODERATION_MAX_BATCHES", 20),
 		"max batches per moderation pass (0 = unlimited)")
 	modDryRun := flag.Bool("moderate-dry-run", envBool("MODERATION_DRY_RUN", false),
 		"log what moderation would delete without deleting it")


### PR DESCRIPTION
## Summary
- Switch the default moderation provider from DeepSeek direct to OpenRouter with `inclusionai/ling-3.0-flash:free` (124B MoE, strong CJK — a good fit for the mostly-Chinese title stream). No free DeepSeek variant currently exists on OpenRouter.
- Reshape the hourly sweep from 40 batches × 50 titles to **20 × 100**: identical 2000 titles/hour ceiling, but ~480 requests/day instead of ~960 — comfortably under OpenRouter's 1000 req/day free-model cap (which requires ≥$10 lifetime credits and also counts retries and any other free-model use on the account).
- Update `env.example`, README (architecture diagram + env table), and the `main.go` flag defaults in sync.

## Notes
- OpenRouter's privacy settings must allow free endpoints (prompts may be used for training), otherwise requests fail with "no endpoints found".
- DeepSeek direct remains a documented one-line switch in `env.example` if free capacity gets flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)