### PR TITLE
Harden the API against DoS attacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ CRAWL_ENABLED=false go run ./cmd/server --seed-demo
 | `FETCH_METADATA` | `true` | 是否获取元数据（false 时只收 infohash） |
 | `MIN_TORRENT_SIZE` | `104857600`（100 MiB） | 低于此总体积的种子不入库 |
 | `ENV_FILE` | `.env` | .env 文件路径（相对工作目录） |
+| `RATE_LIMIT_RPS` | `3` | 每客户端 IP 的持续请求速率（令牌桶，0 = 关闭限流） |
+| `RATE_LIMIT_BURST` | `30` | 令牌桶突发容量 |
+| `SEARCH_MAX_INFLIGHT` | `16` | 并发搜索上限，超出直接 503 甩负载 |
+| `SEARCH_TIMEOUT` | `10s` | 单次搜索的数据库时间预算 |
 
 LLM 审核相关（见下文「LLM 二次审核」）：
 
@@ -114,6 +118,19 @@ npm run dev                  # 开发
 - `GET /api/search?q=xx&page=1&page_size=20` — 搜索（q 为空返回最新收录），结果含拼好的 magnet 链接
 - `GET /api/stats` — 收录数、成人/垃圾/体积过滤计数、LLM 审核统计、爬虫状态
 - `GET /api/healthz` — 健康检查
+
+## DoS 防护
+
+搜索是无鉴权接口，而每次关键词查询都是两遍全表扫描（SQLite 单连接），所以 API 层内置了四道闸门，全部可用环境变量调整（见上表）：
+
+- **每 IP 限流**：令牌桶（默认持续 3 req/s、突发 30），超出返回 429 + `Retry-After`。真实客户端 IP 只信任来自回环/内网地址（反向代理或同机 Next SSR 进程）的 `X-Forwarded-For`，公网直连时伪造头无效；IPv6 按 /64 计桶，防止单机用整段地址刷新桶。`/api/healthz` 不限流，监控和部署健康检查不会被洪水挤掉。
+- **搜索准入**：并发搜索上限（默认 16），等不到槽位（1 秒）直接 503 甩负载——SQLite 只有一个连接，排队再深也只是白占内存。
+- **单查询预算**：每次搜索默认 10s 超时，客户端断开即取消，慢查询不会继续占着数据库；关键词最多取前 8 个（每个关键词都让每行多算两次 LIKE），翻页深度上限 10000 行（`OFFSET` 越深扫描越贵），查询串按 UTF-8 边界截断到 200 字节。
+- **HTTP 层**：Read/Write/Idle 超时加 16 KB 请求头上限，挡 slowloris 和超大头攻击。
+
+另外 `/api/stats` 和首页总数走 10 秒 TTL 的单飞缓存（并发未命中只有一个请求去查库），聚合扫描每周期最多一次；`created_at` 索引让空查询（首页默认请求）从全表排序变成走索引取前 20 行。
+
+前端 SSR 请求会把入站的 `X-Forwarded-For` / `X-Real-IP` 透传给后端，限流按真实访客计——注意反向代理需设置这两个头（nginx: `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;`）。
 
 ## 过滤策略
 

--- a/env.example
+++ b/env.example
@@ -60,3 +60,17 @@ MIN_TORRENT_SIZE=104857600
 # --- Server ---
 # HTTP_ADDR=:8080
 # DB_PATH=./dhtsearch.db
+
+# --- API DoS defenses ---
+# Sustained requests/second allowed per client IP (token bucket, with
+# RATE_LIMIT_BURST of headroom). The real client is taken from
+# X-Forwarded-For only when the request comes from loopback/private
+# addresses (the reverse proxy or the Next.js SSR process); public peers
+# cannot spoof it. 0 disables rate limiting.
+# RATE_LIMIT_RPS=3
+# RATE_LIMIT_BURST=30
+# Concurrent search queries before requests are shed with 503. SQLite
+# serializes queries on one connection anyway; this bounds the queue.
+# SEARCH_MAX_INFLIGHT=16
+# Database time budget per search request.
+# SEARCH_TIMEOUT=10s

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -57,6 +57,15 @@ func envInt64(key string, fallback int64) int64 {
 	return fallback
 }
 
+func envFloat(key string, fallback float64) float64 {
+	if v := os.Getenv(key); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+	return fallback
+}
+
 func main() {
 	logger := log.Default()
 
@@ -78,6 +87,16 @@ func main() {
 	seedDemo := flag.Bool("seed-demo", false, "insert demo records at startup")
 	minSize := flag.Int64("min-size", envInt64("MIN_TORRENT_SIZE", 100<<20),
 		"skip torrents whose total size is below this many bytes")
+
+	// API DoS defenses. See internal/api.Options for what each knob bounds.
+	rateRPS := flag.Float64("rate-rps", envFloat("RATE_LIMIT_RPS", 3),
+		"sustained API requests per second per client IP (0 = disable rate limiting)")
+	rateBurst := flag.Int("rate-burst", envInt("RATE_LIMIT_BURST", 30),
+		"rate limit burst size per client IP")
+	searchInflight := flag.Int("search-max-inflight", envInt("SEARCH_MAX_INFLIGHT", 16),
+		"max concurrent search queries before shedding load")
+	searchTimeout := flag.Duration("search-timeout", envDuration("SEARCH_TIMEOUT", 10*time.Second),
+		"database time budget for one search request")
 
 	// LLM moderation pass.
 	modEnabled := flag.Bool("moderate", envBool("MODERATION_ENABLED", true),
@@ -229,7 +248,9 @@ func main() {
 		}
 	}()
 
-	// HTTP API.
+	// HTTP API. The timeouts close slow-read and slow-write (slowloris)
+	// connections instead of letting each one pin a goroutine and a socket;
+	// MaxHeaderBytes stops oversized header floods from ballooning memory.
 	srv := &http.Server{
 		Addr: *addr,
 		Handler: api.New(st, func() api.CrawlerStatus {
@@ -243,8 +264,17 @@ func main() {
 				SampleErr: cs.SampleErr,
 				Harvested: cs.Harvested,
 			}
-		}, logger).Handler(),
+		}, logger, api.Options{
+			RateRPS:       *rateRPS,
+			RateBurst:     *rateBurst,
+			MaxInflight:   *searchInflight,
+			SearchTimeout: *searchTimeout,
+		}).Handler(),
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       2 * time.Minute,
+		MaxHeaderBytes:    16 << 10,
 	}
 	go func() {
 		<-ctx.Done()

--- a/server/internal/api/api.go
+++ b/server/internal/api/api.go
@@ -2,11 +2,16 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
 
 	"dhtsearch/server/internal/store"
 )
@@ -15,7 +20,37 @@ const (
 	maxQueryLen    = 200
 	maxPageSize    = 100
 	defaultPerPage = 20
+	// maxOffset caps how deep pagination can reach: OFFSET n makes SQLite
+	// walk and discard n rows, so an unbounded page number turns one GET
+	// into a full-table scan. Nothing legitimate paginates 10k results deep.
+	maxOffset = 10_000
+	// admissionWait is how long a search waits for an in-flight slot before
+	// being turned away. Long enough to absorb a burst, short enough that a
+	// flood fails fast instead of stacking goroutines.
+	admissionWait = time.Second
+
+	defaultMaxInflight   = 16
+	defaultSearchTimeout = 10 * time.Second
+	defaultStatsTTL      = 10 * time.Second
 )
+
+// Options tunes the API's DoS defenses. Zero values pick safe defaults,
+// except RateRPS where <= 0 disables per-client rate limiting entirely
+// (tests, fully trusted networks).
+type Options struct {
+	// RateRPS is the sustained per-client request rate; RateBurst is the
+	// bucket size (<= 0: 10 seconds' worth of RateRPS).
+	RateRPS   float64
+	RateBurst int
+	// MaxInflight caps concurrent search queries. The store has one SQLite
+	// connection, so extra concurrency only queues; this bounds the queue.
+	MaxInflight int
+	// SearchTimeout bounds one request's total database time.
+	SearchTimeout time.Duration
+	// StatsTTL is how long stats and total-count responses are served from
+	// cache. Stats hit four aggregate queries; caching makes them O(1).
+	StatsTTL time.Duration
+}
 
 // CrawlerStatus describes the crawler for the stats endpoint. The sampler
 // fields are the ones to watch when discovery looks slow: Nodes is the pool
@@ -37,11 +72,50 @@ type Server struct {
 	crawler func() CrawlerStatus
 	logger  *log.Logger
 	mux     *http.ServeMux
+	opts    Options
+
+	limiter   *ipLimiter    // nil when rate limiting is disabled
+	searchSem chan struct{} // admission gate for search queries
+
+	// Cached /api/stats body and empty-query total, both refreshed at most
+	// once per StatsTTL. The mutexes double as single-flight: one request
+	// pays for the refresh while the rest wait for its result.
+	statsMu   sync.Mutex
+	statsBody []byte
+	statsAt   time.Time
+	countMu   sync.Mutex
+	countVal  int
+	countAt   time.Time
 }
 
 // New builds the HTTP handler. crawlerStatus may be nil.
-func New(st *store.Store, crawlerStatus func() CrawlerStatus, logger *log.Logger) *Server {
-	s := &Server{st: st, crawler: crawlerStatus, logger: logger}
+func New(st *store.Store, crawlerStatus func() CrawlerStatus, logger *log.Logger, opts Options) *Server {
+	if logger == nil {
+		logger = log.Default()
+	}
+	if opts.MaxInflight <= 0 {
+		opts.MaxInflight = defaultMaxInflight
+	}
+	if opts.SearchTimeout <= 0 {
+		opts.SearchTimeout = defaultSearchTimeout
+	}
+	if opts.StatsTTL <= 0 {
+		opts.StatsTTL = defaultStatsTTL
+	}
+	s := &Server{
+		st:        st,
+		crawler:   crawlerStatus,
+		logger:    logger,
+		opts:      opts,
+		searchSem: make(chan struct{}, opts.MaxInflight),
+	}
+	if opts.RateRPS > 0 {
+		burst := opts.RateBurst
+		if burst <= 0 {
+			burst = int(opts.RateRPS*10) + 1
+		}
+		s.limiter = newIPLimiter(opts.RateRPS, burst)
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/search", s.handleSearch)
 	mux.HandleFunc("GET /api/stats", s.handleStats)
@@ -50,7 +124,9 @@ func New(st *store.Store, crawlerStatus func() CrawlerStatus, logger *log.Logger
 	return s
 }
 
-// Handler returns the root handler with CORS/OPTIONS support.
+// Handler returns the root handler with CORS/OPTIONS support and per-client
+// rate limiting. The health check is exempt so monitoring and the deploy
+// script never get throttled behind a flood.
 func (s *Server) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -58,6 +134,11 @@ func (s *Server) Handler() http.Handler {
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if s.limiter != nil && r.URL.Path != "/api/healthz" && !s.limiter.allow(clientKey(r)) {
+			w.Header().Set("Retry-After", "1")
+			writeError(w, http.StatusTooManyRequests, "rate limit exceeded")
 			return
 		}
 		s.mux.ServeHTTP(w, r)
@@ -75,10 +156,7 @@ type resultItem struct {
 }
 
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
-	q := r.URL.Query().Get("q")
-	if len(q) > maxQueryLen {
-		q = q[:maxQueryLen]
-	}
+	q := truncateUTF8(r.URL.Query().Get("q"), maxQueryLen)
 	page := atoiDefault(r.URL.Query().Get("page"), 1)
 	if page < 1 {
 		page = 1
@@ -90,10 +168,51 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	if pageSize > maxPageSize {
 		pageSize = maxPageSize
 	}
+	if (page-1)*pageSize > maxOffset {
+		page = maxOffset/pageSize + 1
+	}
 
-	items, total, err := s.st.Search(q, page, pageSize)
+	// Admission gate: the store serializes queries on one connection, so
+	// when all slots are busy piling on more requests only grows the queue.
+	// Wait briefly for a slot, then shed load instead of stacking up.
+	select {
+	case s.searchSem <- struct{}{}:
+		defer func() { <-s.searchSem }()
+	case <-r.Context().Done():
+		return
+	case <-time.After(admissionWait):
+		w.Header().Set("Retry-After", "2")
+		writeError(w, http.StatusServiceUnavailable, "server busy")
+		return
+	}
+
+	// The context bounds database time and dies with the client connection,
+	// so queries for hung-up clients stop consuming the SQLite handle.
+	ctx, cancel := context.WithTimeout(r.Context(), s.opts.SearchTimeout)
+	defer cancel()
+
+	var (
+		items []store.Torrent
+		total int
+		err   error
+	)
+	if strings.TrimSpace(q) == "" {
+		// The landing page. Latest walks the created_at index instead of
+		// counting matches, and the total comes from the shared cache.
+		items, err = s.st.Latest(ctx, page, pageSize)
+		if err == nil {
+			total, err = s.cachedCount(ctx)
+		}
+	} else {
+		items, total, err = s.st.Search(ctx, q, page, pageSize)
+	}
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "search failed")
+		if ctx.Err() != nil {
+			w.Header().Set("Retry-After", "5")
+			writeError(w, http.StatusServiceUnavailable, "search timed out")
+		} else {
+			writeError(w, http.StatusInternalServerError, "search failed")
+		}
 		s.logger.Printf("api: search: %v", err)
 		return
 	}
@@ -117,23 +236,54 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// cachedCount returns the total torrent count, at most StatsTTL stale.
+// COUNT(*) walks a full index, so the landing page must not pay for it per
+// request. The lock is held across the query on purpose: it makes concurrent
+// misses single-flight.
+func (s *Server) cachedCount(ctx context.Context) (int, error) {
+	s.countMu.Lock()
+	defer s.countMu.Unlock()
+	if !s.countAt.IsZero() && time.Since(s.countAt) < s.opts.StatsTTL {
+		return s.countVal, nil
+	}
+	n, err := s.st.Count(ctx)
+	if err != nil {
+		return 0, err
+	}
+	s.countVal, s.countAt = n, time.Now()
+	return n, nil
+}
+
 func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
-	total, err := s.st.Count()
+	// Single-flight with a TTL: stats aggregate four queries (two of them
+	// full scans), so one refresh per TTL serves everyone. The lock being
+	// held across the refresh is what keeps a stats flood down to one
+	// query stream.
+	s.statsMu.Lock()
+	defer s.statsMu.Unlock()
+	if s.statsBody != nil && time.Since(s.statsAt) < s.opts.StatsTTL {
+		writeRawJSON(w, http.StatusOK, s.statsBody)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), s.opts.SearchTimeout)
+	defer cancel()
+
+	total, err := s.st.Count(ctx)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "stats failed")
 		return
 	}
-	counters, err := s.st.Stats()
+	counters, err := s.st.Stats(ctx)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "stats failed")
 		return
 	}
-	blocked, err := s.st.BlockedCount()
+	blocked, err := s.st.BlockedCount(ctx)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "stats failed")
 		return
 	}
-	pending, err := s.st.PendingReviewCount()
+	pending, err := s.st.PendingReviewCount(ctx)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "stats failed")
 		return
@@ -164,7 +314,13 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	if s.crawler != nil {
 		resp["crawler"] = s.crawler()
 	}
-	writeJSON(w, http.StatusOK, resp)
+	body, err := json.Marshal(resp)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "stats failed")
+		return
+	}
+	s.statsBody, s.statsAt = body, time.Now()
+	writeRawJSON(w, http.StatusOK, body)
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -182,10 +338,27 @@ func atoiDefault(s string, def int) int {
 	return def
 }
 
+// truncateUTF8 cuts s to at most n bytes without splitting a multi-byte rune.
+func truncateUTF8(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n]
+}
+
 func writeJSON(w http.ResponseWriter, code int, v any) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(code)
 	json.NewEncoder(w).Encode(v)
+}
+
+func writeRawJSON(w http.ResponseWriter, code int, body []byte) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(code)
+	w.Write(body)
 }
 
 func writeError(w http.ResponseWriter, code int, msg string) {

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func testServer(t *testing.T) *httptest.Server {
+	return testServerOpts(t, Options{})
+}
+
+func testServerOpts(t *testing.T, opts Options) *httptest.Server {
 	t.Helper()
 	st, err := store.Open(":memory:")
 	if err != nil {
@@ -32,7 +36,7 @@ func testServer(t *testing.T) *httptest.Server {
 	}
 	srv := httptest.NewServer(New(st, func() CrawlerStatus {
 		return CrawlerStatus{Enabled: false, Seen: 42}
-	}, nil).Handler())
+	}, nil, opts).Handler())
 	t.Cleanup(srv.Close)
 	return srv
 }
@@ -89,6 +93,15 @@ func TestSearch(t *testing.T) {
 	m = getJSON(t, base+"/api/search?q=&page_size=1&page=2")
 	if len(m["results"].([]any)) != 1 || m["page"].(float64) != 2 {
 		t.Fatalf("pagination: %v", m)
+	}
+}
+
+// A huge page number must not translate into a huge OFFSET scan.
+func TestSearchClampsDeepPagination(t *testing.T) {
+	base := testServer(t).URL
+	m := getJSON(t, base+"/api/search?q=&page=99999999&page_size=100")
+	if got, want := m["page"].(float64), float64(maxOffset/100+1); got != want {
+		t.Fatalf("page = %v, want clamped to %v", got, want)
 	}
 }
 

--- a/server/internal/api/ratelimit.go
+++ b/server/internal/api/ratelimit.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// Idle buckets are dropped after this long. At any configured rate a
+	// bucket refills to full well before that, so eviction never costs a
+	// returning client tokens it was still owed.
+	bucketIdleTTL = 10 * time.Minute
+	sweepEvery    = time.Minute
+	// Hard cap on tracked addresses; when a large botnet pushes the map past
+	// this, sweeping runs on every call until it shrinks, so memory stays
+	// bounded even if the timer-based sweep cannot keep up.
+	maxBuckets = 1 << 17
+)
+
+// ipLimiter is a token-bucket rate limiter keyed by client address. Every
+// query on this API is answered from a single SQLite connection, and a
+// keyword search is two full-table scans — so a cheap, unauthenticated flood
+// of GETs is enough to starve the crawler and every other client. This
+// per-client bucket is the first line of defense; the search handler's
+// admission gate (see api.go) is the second.
+type ipLimiter struct {
+	rate  float64 // tokens added per second
+	burst float64 // bucket capacity
+
+	mu        sync.Mutex
+	buckets   map[string]*bucket
+	lastSweep time.Time
+	now       func() time.Time // injectable clock for tests
+}
+
+type bucket struct {
+	tokens float64
+	last   time.Time
+}
+
+func newIPLimiter(rate float64, burst int) *ipLimiter {
+	return &ipLimiter{
+		rate:    rate,
+		burst:   float64(burst),
+		buckets: make(map[string]*bucket),
+		now:     time.Now,
+	}
+}
+
+// allow reports whether the client identified by key may proceed, consuming
+// one token if so.
+func (l *ipLimiter) allow(key string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := l.now()
+	if now.Sub(l.lastSweep) >= sweepEvery || len(l.buckets) > maxBuckets {
+		l.sweep(now)
+	}
+	b, ok := l.buckets[key]
+	if !ok {
+		b = &bucket{tokens: l.burst, last: now}
+		l.buckets[key] = b
+	} else {
+		b.tokens = min(l.burst, b.tokens+now.Sub(b.last).Seconds()*l.rate)
+		b.last = now
+	}
+	if b.tokens < 1 {
+		return false
+	}
+	b.tokens--
+	return true
+}
+
+func (l *ipLimiter) sweep(now time.Time) {
+	l.lastSweep = now
+	for k, b := range l.buckets {
+		if now.Sub(b.last) > bucketIdleTTL {
+			delete(l.buckets, k)
+		}
+	}
+}
+
+// clientKey returns the rate-limit key for a request: the client address,
+// resolved through forwarding headers only when the direct peer is itself
+// trusted infrastructure (loopback or private — the reverse proxy or the
+// Next.js SSR process on the same box). A public peer's forwarding headers
+// are attacker-controlled and ignored, so hitting the API directly with a
+// spoofed X-Forwarded-For cannot borrow someone else's bucket.
+func clientKey(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	peer, err := netip.ParseAddr(host)
+	if err != nil {
+		return host
+	}
+	if trustedPeer(peer) {
+		if fwd, ok := forwardedClient(r); ok {
+			return bucketKey(fwd)
+		}
+	}
+	return bucketKey(peer)
+}
+
+func trustedPeer(a netip.Addr) bool {
+	a = a.Unmap()
+	return a.IsLoopback() || a.IsPrivate() || a.IsLinkLocalUnicast()
+}
+
+// forwardedClient extracts the client from X-Forwarded-For by walking right
+// to left and skipping trusted hops: each proxy appends the peer it saw, so
+// the rightmost untrusted address is the one our own infrastructure vouches
+// for. Anything left of it came from the client and is spoofable. Malformed
+// entries stop the walk rather than let garbage promote a spoofed hop.
+func forwardedClient(r *http.Request) (netip.Addr, bool) {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		hops := strings.Split(xff, ",")
+		for i := len(hops) - 1; i >= 0; i-- {
+			a, err := netip.ParseAddr(strings.TrimSpace(hops[i]))
+			if err != nil {
+				break
+			}
+			if !trustedPeer(a) {
+				return a.Unmap(), true
+			}
+		}
+	}
+	if xr := r.Header.Get("X-Real-IP"); xr != "" {
+		if a, err := netip.ParseAddr(strings.TrimSpace(xr)); err == nil {
+			return a.Unmap(), true
+		}
+	}
+	return netip.Addr{}, false
+}
+
+// bucketKey collapses IPv6 clients to their /64: a single host routinely
+// owns a whole /64, so per-address buckets would hand an IPv6 attacker
+// effectively unlimited fresh buckets.
+func bucketKey(a netip.Addr) string {
+	a = a.Unmap().WithZone("")
+	if a.Is4() {
+		return a.String()
+	}
+	return netip.PrefixFrom(a, 64).Masked().String()
+}

--- a/server/internal/api/ratelimit_test.go
+++ b/server/internal/api/ratelimit_test.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestIPLimiterRefillAndIsolation(t *testing.T) {
+	l := newIPLimiter(1, 2) // 1 rps, burst 2
+	now := time.Unix(1000, 0)
+	l.now = func() time.Time { return now }
+
+	if !l.allow("a") || !l.allow("a") {
+		t.Fatal("burst of 2 should be allowed")
+	}
+	if l.allow("a") {
+		t.Fatal("third immediate request should be rejected")
+	}
+	// A different client has its own bucket.
+	if !l.allow("b") {
+		t.Fatal("second client must not share the first client's bucket")
+	}
+	// One second refills one token.
+	now = now.Add(time.Second)
+	if !l.allow("a") {
+		t.Fatal("token should have refilled after 1s")
+	}
+	if l.allow("a") {
+		t.Fatal("refill must not exceed elapsed time * rate")
+	}
+}
+
+func TestIPLimiterSweepsIdleBuckets(t *testing.T) {
+	l := newIPLimiter(1, 1)
+	now := time.Unix(1000, 0)
+	l.now = func() time.Time { return now }
+
+	l.allow("a")
+	now = now.Add(bucketIdleTTL + sweepEvery)
+	l.allow("b") // triggers the sweep
+	l.mu.Lock()
+	_, stale := l.buckets["a"]
+	l.mu.Unlock()
+	if stale {
+		t.Fatal("idle bucket survived the sweep")
+	}
+}
+
+func TestClientKey(t *testing.T) {
+	req := func(remote, xff, realIP string) *http.Request {
+		r := httptest.NewRequest("GET", "/api/search", nil)
+		r.RemoteAddr = remote
+		if xff != "" {
+			r.Header.Set("X-Forwarded-For", xff)
+		}
+		if realIP != "" {
+			r.Header.Set("X-Real-IP", realIP)
+		}
+		return r
+	}
+	cases := []struct {
+		name            string
+		remote, xff, xr string
+		want            string
+	}{
+		// A public peer's forwarding headers are spoofable — ignored.
+		{"public peer ignores xff", "203.0.113.7:1234", "198.51.100.1", "", "203.0.113.7"},
+		// A trusted proxy vouches for the rightmost untrusted hop only.
+		{"proxy forwards client", "127.0.0.1:80", "198.51.100.1", "", "198.51.100.1"},
+		{"client-supplied hop ignored", "127.0.0.1:80", "1.2.3.4, 198.51.100.1", "", "198.51.100.1"},
+		{"chain of trusted proxies", "127.0.0.1:80", "198.51.100.1, 10.0.0.5", "", "198.51.100.1"},
+		{"garbage stops the walk", "127.0.0.1:80", "1.2.3.4, garbage, 10.0.0.5", "", "127.0.0.1"},
+		{"x-real-ip fallback", "127.0.0.1:80", "", "198.51.100.1", "198.51.100.1"},
+		{"no headers keys the peer", "127.0.0.1:80", "", "", "127.0.0.1"},
+		// IPv6 clients are bucketed by /64.
+		{"ipv6 collapsed to /64", "[2001:db8:1:2:3:4:5:6]:443", "", "", "2001:db8:1:2::/64"},
+	}
+	for _, c := range cases {
+		if got := clientKey(req(c.remote, c.xff, c.xr)); got != c.want {
+			t.Errorf("%s: clientKey = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestRateLimitedEndpoint(t *testing.T) {
+	base := testServerOpts(t, Options{RateRPS: 0.001, RateBurst: 2})
+
+	get := func(path string) int {
+		t.Helper()
+		resp, err := http.Get(base.URL + path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+	if got := get("/api/search?q="); got != http.StatusOK {
+		t.Fatalf("first request: status %d", got)
+	}
+	if got := get("/api/search?q="); got != http.StatusOK {
+		t.Fatalf("second request: status %d", got)
+	}
+	if got := get("/api/search?q="); got != http.StatusTooManyRequests {
+		t.Fatalf("over-budget request: status %d, want 429", got)
+	}
+	// The health check must stay reachable during a flood.
+	if got := get("/api/healthz"); got != http.StatusOK {
+		t.Fatalf("healthz while throttled: status %d", got)
+	}
+}
+
+func TestTruncateUTF8(t *testing.T) {
+	// 3-byte runes; a naive byte cut at 200 would split one.
+	s := ""
+	for len(s) <= maxQueryLen {
+		s += "宇"
+	}
+	got := truncateUTF8(s, maxQueryLen)
+	if len(got) > maxQueryLen {
+		t.Fatalf("truncated to %d bytes, want <= %d", len(got), maxQueryLen)
+	}
+	if len(got)%3 != 0 {
+		t.Fatalf("cut split a rune: %d bytes", len(got))
+	}
+	if truncateUTF8("abc", 200) != "abc" {
+		t.Fatal("short strings must pass through")
+	}
+}

--- a/server/internal/moderator/moderator_test.go
+++ b/server/internal/moderator/moderator_test.go
@@ -115,7 +115,7 @@ func TestSweepRemovesAdultAndSpamKeepsOK(t *testing.T) {
 		t.Fatalf("summary = %+v", s)
 	}
 
-	items, total, err := st.Search("", 1, 10)
+	items, total, err := st.Search(t.Context(), "", 1, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,7 +146,7 @@ func TestReviewedRowsAreNotReclassified(t *testing.T) {
 	if got := atomic.LoadInt32(&calls); got != first {
 		t.Fatalf("second sweep made %d extra API calls, want 0", got-first)
 	}
-	if n, _ := st.PendingReviewCount(); n != 0 {
+	if n, _ := st.PendingReviewCount(t.Context()); n != 0 {
 		t.Fatalf("pending = %d, want 0", n)
 	}
 }
@@ -165,10 +165,10 @@ func TestBlockedTorrentIsNotReAdded(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if _, total, _ := st.Search("", 1, 10); total != 0 {
+	if _, total, _ := st.Search(t.Context(), "", 1, 10); total != 0 {
 		t.Fatalf("blocked infohash was re-added (total=%d)", total)
 	}
-	if n, _ := st.BlockedCount(); n != 1 {
+	if n, _ := st.BlockedCount(t.Context()); n != 1 {
 		t.Fatalf("blocked count = %d, want 1", n)
 	}
 }
@@ -186,7 +186,7 @@ func TestDryRunDeletesNothing(t *testing.T) {
 	if s.Adult != 1 || s.Deleted != 0 {
 		t.Fatalf("summary = %+v, want Adult=1 Deleted=0", s)
 	}
-	if _, total, _ := st.Search("", 1, 10); total != 1 {
+	if _, total, _ := st.Search(t.Context(), "", 1, 10); total != 1 {
 		t.Fatalf("dry run deleted rows (total=%d)", total)
 	}
 }
@@ -203,10 +203,10 @@ func TestAPIErrorLeavesRowsUnreviewed(t *testing.T) {
 	if _, err := newMod(t, st, srv.URL, nil).SweepOnce(context.Background()); err == nil {
 		t.Fatal("expected error from 401")
 	}
-	if n, _ := st.PendingReviewCount(); n != 1 {
+	if n, _ := st.PendingReviewCount(t.Context()); n != 1 {
 		t.Fatalf("pending = %d, want 1 (row must be retried)", n)
 	}
-	if _, total, _ := st.Search("", 1, 10); total != 1 {
+	if _, total, _ := st.Search(t.Context(), "", 1, 10); total != 1 {
 		t.Fatalf("row deleted on API error (total=%d)", total)
 	}
 }
@@ -257,7 +257,7 @@ func TestUnknownAndMissingLabelsDefaultToOK(t *testing.T) {
 	if s.Deleted != 0 {
 		t.Fatalf("deleted %d rows on malformed verdicts, want 0", s.Deleted)
 	}
-	if _, total, _ := st.Search("", 1, 10); total != 3 {
+	if _, total, _ := st.Search(t.Context(), "", 1, 10); total != 3 {
 		t.Fatalf("total = %d, want 3", total)
 	}
 }

--- a/server/internal/moderator/trim_test.go
+++ b/server/internal/moderator/trim_test.go
@@ -188,7 +188,7 @@ func TestSweepTrimsAdvertisingFromTitles(t *testing.T) {
 		t.Errorf("Trimmed = %d, want 1", s.Trimmed)
 	}
 
-	items, _, err := st.Search("", 1, 10)
+	items, _, err := st.Search(t.Context(), "", 1, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +222,7 @@ func TestTrimmedTorrentIsStillFoundByRawText(t *testing.T) {
 	}
 
 	for _, q := range []string{"spam.net", "Blue Bloods"} {
-		items, total, err := st.Search(q, 1, 10)
+		items, total, err := st.Search(t.Context(), q, 1, 10)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -246,7 +246,7 @@ func TestTrimDisabledLeavesTitlesAlone(t *testing.T) {
 	if s.Trimmed != 0 {
 		t.Errorf("Trimmed = %d, want 0", s.Trimmed)
 	}
-	items, _, err := st.Search("", 1, 10)
+	items, _, err := st.Search(t.Context(), "", 1, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -265,7 +265,7 @@ func TestDryRunTrimsNothing(t *testing.T) {
 	if _, err := m.SweepOnce(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	items, _, err := st.Search("", 1, 10)
+	items, _, err := st.Search(t.Context(), "", 1, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -289,7 +289,7 @@ func TestSweepRejectsRewrittenTitles(t *testing.T) {
 	if s.Trimmed != 0 {
 		t.Errorf("Trimmed = %d, want 0", s.Trimmed)
 	}
-	items, _, err := st.Search("", 1, 10)
+	items, _, err := st.Search(t.Context(), "", 1, 10)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -4,6 +4,7 @@ package store
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -110,6 +111,14 @@ CREATE TABLE IF NOT EXISTS blocked (
 		ON torrents(created_at) WHERE reviewed_at = 0`); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("create unreviewed index: %w", err)
+	}
+	// Newest-first is the sort order of every search. Without this index an
+	// empty query — the landing page — sorts the whole table per request,
+	// and a keyword query cannot stop early after filling its page.
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_torrents_created
+		ON torrents(created_at DESC)`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("create created_at index: %w", err)
 	}
 	return &Store{db: db}, nil
 }
@@ -244,15 +253,32 @@ func (s *Store) Upsert(t Torrent) error {
 	return err
 }
 
+// maxKeywords bounds how many query keywords turn into LIKE conditions.
+// Each keyword adds two LIKE evaluations per scanned row, so an unbounded
+// list lets one request multiply its own scan cost ~100x. Past a handful of
+// keywords extra terms only narrow an already tiny result set; the tail is
+// ignored.
+const maxKeywords = 8
+
+// selectCols is the projection shared by Search and Latest, decoded by
+// scanTorrents.
+const selectCols = `SELECT info_hash, IIF(clean_name <> '', clean_name, name),
+	total_size, file_count, files, created_at FROM torrents`
+
 // Search finds torrents whose name contains every space-separated keyword
 // of query (AND semantics), newest first. An empty query returns the latest
-// additions. page is 1-based; pageSize must be > 0.
-func (s *Store) Search(query string, page, pageSize int) (items []Torrent, total int, err error) {
+// additions. page is 1-based; pageSize must be > 0. ctx bounds the queries:
+// keyword matching is a full-table scan, so callers must be able to cut it
+// off when the client hangs up or a deadline passes.
+func (s *Store) Search(ctx context.Context, query string, page, pageSize int) (items []Torrent, total int, err error) {
 	if page < 1 {
 		page = 1
 	}
 	where, args := "", []interface{}{}
 	keywords := strings.Fields(query)
+	if len(keywords) > maxKeywords {
+		keywords = keywords[:maxKeywords]
+	}
 	if len(keywords) > 0 {
 		var conds []string
 		for _, kw := range keywords {
@@ -264,32 +290,53 @@ func (s *Store) Search(query string, page, pageSize int) (items []Torrent, total
 		}
 		where = " WHERE " + strings.Join(conds, " AND ")
 	}
-	if err = s.db.QueryRow(`SELECT COUNT(*) FROM torrents`+where, args...).Scan(&total); err != nil {
+	if err = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM torrents`+where, args...).Scan(&total); err != nil {
 		return nil, 0, err
 	}
-	q := `SELECT info_hash, IIF(clean_name <> '', clean_name, name), total_size, file_count, files, created_at
-	      FROM torrents` + where + ` ORDER BY created_at DESC LIMIT ? OFFSET ?`
-	rows, err := s.db.Query(q, append(args, pageSize, (page-1)*pageSize)...)
+	q := selectCols + where + ` ORDER BY created_at DESC LIMIT ? OFFSET ?`
+	rows, err := s.db.QueryContext(ctx, q, append(args, pageSize, (page-1)*pageSize)...)
 	if err != nil {
 		return nil, 0, err
 	}
+	items, err = scanTorrents(rows)
+	return items, total, err
+}
+
+// Latest returns a page of the newest torrents without counting the table.
+// It walks the created_at index, so its cost is O(pageSize + offset) — the
+// cheap path the landing page should take instead of Search("").
+func (s *Store) Latest(ctx context.Context, page, pageSize int) ([]Torrent, error) {
+	if page < 1 {
+		page = 1
+	}
+	rows, err := s.db.QueryContext(ctx,
+		selectCols+` ORDER BY created_at DESC LIMIT ? OFFSET ?`, pageSize, (page-1)*pageSize)
+	if err != nil {
+		return nil, err
+	}
+	return scanTorrents(rows)
+}
+
+// scanTorrents drains rows from a selectCols query, decompressing each file
+// list. It always closes rows.
+func scanTorrents(rows *sql.Rows) (items []Torrent, err error) {
 	defer rows.Close()
 	for rows.Next() {
 		var t Torrent
 		var fb []byte
 		if err := rows.Scan(&t.InfoHash, &t.Name, &t.TotalSize, &t.FileCount, &fb, &t.CreatedAt); err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		fj, err := decompressFiles(fb)
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		if err := json.Unmarshal(fj, &t.Files); err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		items = append(items, t)
 	}
-	return items, total, rows.Err()
+	return items, rows.Err()
 }
 
 // Unreviewed returns up to limit torrents the moderation pass has not seen
@@ -409,16 +456,16 @@ func (s *Store) Block(hashes, names []string, reason string, ts int64) (int64, e
 }
 
 // BlockedCount returns the number of moderation-rejected infohashes.
-func (s *Store) BlockedCount() (int, error) {
+func (s *Store) BlockedCount(ctx context.Context) (int, error) {
 	var n int
-	err := s.db.QueryRow(`SELECT COUNT(*) FROM blocked`).Scan(&n)
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM blocked`).Scan(&n)
 	return n, err
 }
 
 // PendingReviewCount returns how many stored torrents await moderation.
-func (s *Store) PendingReviewCount() (int, error) {
+func (s *Store) PendingReviewCount(ctx context.Context) (int, error) {
 	var n int
-	err := s.db.QueryRow(`SELECT COUNT(*) FROM torrents WHERE reviewed_at = 0`).Scan(&n)
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM torrents WHERE reviewed_at = 0`).Scan(&n)
 	return n, err
 }
 
@@ -436,8 +483,8 @@ func (s *Store) IncrStat(key string, delta int64) error {
 }
 
 // Stats returns all pipeline counters.
-func (s *Store) Stats() (map[string]int64, error) {
-	rows, err := s.db.Query(`SELECT key, value FROM stats`)
+func (s *Store) Stats(ctx context.Context) (map[string]int64, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT key, value FROM stats`)
 	if err != nil {
 		return nil, err
 	}
@@ -455,9 +502,9 @@ func (s *Store) Stats() (map[string]int64, error) {
 }
 
 // Count returns the number of stored torrents.
-func (s *Store) Count() (int, error) {
+func (s *Store) Count(ctx context.Context) (int, error) {
 	var n int
-	err := s.db.QueryRow(`SELECT COUNT(*) FROM torrents`).Scan(&n)
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM torrents`).Scan(&n)
 	return n, err
 }
 

--- a/server/internal/store/store_test.go
+++ b/server/internal/store/store_test.go
@@ -39,7 +39,7 @@ func TestUpsertAndSearch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	items, total, err := s.Search("", 1, 10)
+	items, total, err := s.Search(t.Context(), "", 1, 10)
 	if err != nil || total != 3 || len(items) != 3 {
 		t.Fatalf("empty search: items=%d total=%d err=%v", len(items), total, err)
 	}
@@ -47,7 +47,7 @@ func TestUpsertAndSearch(t *testing.T) {
 		t.Fatalf("expected newest first, got %q", items[0].InfoHash)
 	}
 
-	items, total, err = s.Search("big bunny", 1, 10)
+	items, total, err = s.Search(t.Context(), "big bunny", 1, 10)
 	if err != nil || total != 1 || items[0].InfoHash != "aa" {
 		t.Fatalf("keyword search: items=%v total=%d err=%v", items, total, err)
 	}
@@ -56,13 +56,13 @@ func TestUpsertAndSearch(t *testing.T) {
 	}
 
 	// LIKE wildcards in the query must be literal.
-	_, total, err = s.Search("100%", 1, 10)
+	_, total, err = s.Search(t.Context(), "100%", 1, 10)
 	if err != nil || total != 0 {
 		t.Fatalf("wildcard query: total=%d err=%v", total, err)
 	}
 
 	// Pagination.
-	items, total, err = s.Search("", 2, 2)
+	items, total, err = s.Search(t.Context(), "", 2, 2)
 	if err != nil || total != 3 || len(items) != 1 || items[0].InfoHash != "aa" {
 		t.Fatalf("pagination: items=%v total=%d err=%v", items, total, err)
 	}
@@ -98,10 +98,10 @@ func TestUnreviewedMarkReviewedAndBlock(t *testing.T) {
 	if cands, err = s.Unreviewed(10); err != nil || len(cands) != 0 {
 		t.Fatalf("after review: %d cands err=%v", len(cands), err)
 	}
-	if pending, _ := s.PendingReviewCount(); pending != 0 {
+	if pending, _ := s.PendingReviewCount(t.Context()); pending != 0 {
 		t.Fatalf("pending=%d, want 0", pending)
 	}
-	if blocked, _ := s.BlockedCount(); blocked != 1 {
+	if blocked, _ := s.BlockedCount(t.Context()); blocked != 1 {
 		t.Fatalf("blocked=%d, want 1", blocked)
 	}
 
@@ -109,7 +109,7 @@ func TestUnreviewedMarkReviewedAndBlock(t *testing.T) {
 	if err := s.Upsert(Torrent{InfoHash: "bb", Name: "drop me", TotalSize: 1 << 30, CreatedAt: 900}); err != nil {
 		t.Fatal(err)
 	}
-	if total, _ := s.Count(); total != 1 {
+	if total, _ := s.Count(t.Context()); total != 1 {
 		t.Fatalf("count=%d, want 1 (blocked hash was re-added)", total)
 	}
 }
@@ -129,7 +129,7 @@ func TestStats(t *testing.T) {
 	if err := s.IncrStat("seen", 2); err != nil {
 		t.Fatal(err)
 	}
-	m, err := s.Stats()
+	m, err := s.Stats(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,10 +167,10 @@ func TestOpenMigratesPreModerationDB(t *testing.T) {
 	t.Cleanup(func() { s.Close() })
 
 	// The pre-existing row survives and counts as unreviewed.
-	if total, _ := s.Count(); total != 1 {
+	if total, _ := s.Count(t.Context()); total != 1 {
 		t.Fatalf("count=%d, want 1", total)
 	}
-	n, err := s.PendingReviewCount()
+	n, err := s.PendingReviewCount(t.Context())
 	if err != nil || n != 1 {
 		t.Fatalf("pending=%d err=%v, want 1", n, err)
 	}
@@ -248,7 +248,7 @@ func TestOpenMigratesFilesJSONToCompressedBlob(t *testing.T) {
 		t.Fatalf("stored blob is %d bytes, want (0, %d)", blobLen, len(fj))
 	}
 
-	items, total, err := s.Search("", 1, 10)
+	items, total, err := s.Search(t.Context(), "", 1, 10)
 	if err != nil || total != 2 {
 		t.Fatalf("search after migration: total=%d err=%v", total, err)
 	}
@@ -298,7 +298,7 @@ func TestSetCleanNamesReplacesDisplayNameOnly(t *testing.T) {
 	}
 
 	// Search returns the cleaned title...
-	items, _, err := s.Search("", 1, 10)
+	items, _, err := s.Search(t.Context(), "", 1, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestSetCleanNamesReplacesDisplayNameOnly(t *testing.T) {
 		t.Errorf("stored name = %q, want the raw title %q", stored, raw)
 	}
 	for _, q := range []string{"spam.net", "Blue Bloods", "Bloods 1080p"} {
-		if _, total, err := s.Search(q, 1, 10); err != nil || total != 1 {
+		if _, total, err := s.Search(t.Context(), q, 1, 10); err != nil || total != 1 {
 			t.Errorf("Search(%q) total = %d err = %v, want 1", q, total, err)
 		}
 	}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,8 +1,29 @@
 // API client for the DHTSearch Go backend.
 // Base URL is configurable via NEXT_PUBLIC_API_BASE.
 
+import { headers } from "next/headers";
+
 export const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8080";
+
+// Forward the caller's identity on server-side API requests. The Go backend
+// rate-limits per client IP; without these headers every SSR fetch would
+// arrive from the Next server's own address, so one abusive visitor could
+// exhaust the shared bucket for everyone.
+async function clientIPHeaders(): Promise<Record<string, string>> {
+  try {
+    const h = await headers();
+    const out: Record<string, string> = {};
+    const xff = h.get("x-forwarded-for");
+    if (xff) out["x-forwarded-for"] = xff;
+    const realIP = h.get("x-real-ip");
+    if (realIP) out["x-real-ip"] = realIP;
+    return out;
+  } catch {
+    // Outside a request scope (e.g. build time) there is nothing to forward.
+    return {};
+  }
+}
 
 export interface TorrentFile {
   path: string;
@@ -47,7 +68,14 @@ export async function fetchSearch(
   });
   const res = await fetch(`${API_BASE}/api/search?${params.toString()}`, {
     cache: "no-store",
+    headers: await clientIPHeaders(),
   });
+  if (res.status === 429) {
+    throw new Error("请求过于频繁，请稍后重试");
+  }
+  if (res.status === 503) {
+    throw new Error("服务器繁忙，请稍后重试");
+  }
   if (!res.ok) {
     throw new Error(`search API returned ${res.status}`);
   }
@@ -56,7 +84,10 @@ export async function fetchSearch(
 
 export async function fetchStats(): Promise<StatsResponse | null> {
   try {
-    const res = await fetch(`${API_BASE}/api/stats`, { cache: "no-store" });
+    const res = await fetch(`${API_BASE}/api/stats`, {
+      cache: "no-store",
+      headers: await clientIPHeaders(),
+    });
     if (!res.ok) return null;
     return (await res.json()) as StatsResponse;
   } catch {


### PR DESCRIPTION
## Why

`/api/search` is unauthenticated and every keyword query is two full-table LIKE scans on a single SQLite connection — a trivial GET flood starves the crawler and all other clients. The HTTP server also had no read/write/idle timeouts (slowloris) and no cap on pagination depth or keyword count, so single requests could be made arbitrarily expensive.

## Defenses (all tunable via env vars, see README)

- **Per-IP rate limiting** — token bucket (default 3 rps sustained, burst 30), 429 + `Retry-After`. Client IP resolved through `X-Forwarded-For` only when the direct peer is loopback/private (the reverse proxy or same-box Next SSR), so public peers can't spoof into a fresh bucket. IPv6 bucketed per /64. Idle buckets swept, map size hard-capped. `/api/healthz` exempt so monitoring and the deploy health check survive a flood.
- **Search admission gate** — bounded in-flight queries (default 16); after a 1s wait requests are shed with 503 instead of stacking goroutines on the serialized SQLite handle.
- **Per-request budget** — searches run under a 10s context that also dies with the client connection; keywords capped at 8 (each adds two LIKE evaluations per scanned row), pagination depth capped at 10k rows, query truncated on UTF-8 boundaries.
- **HTTP layer** — `ReadTimeout`/`WriteTimeout`/`IdleTimeout` + 16 KB `MaxHeaderBytes`.
- **Cost removal** — new `created_at` index so the landing page walks an index instead of sorting the whole table per request; `/api/stats` and the empty-query total served from a 10s single-flight cache (one aggregate scan per TTL regardless of load).
- **Web** — SSR fetches forward `X-Forwarded-For`/`X-Real-IP` so the limiter sees real visitors, and 429/503 render friendly messages.

## Verified

- `gofmt`, `go vet ./...`, `go test ./...` all green (new tests: limiter refill/isolation/sweep, XFF trust walk incl. spoof cases, 429 endpoint behavior + healthz exemption, deep-pagination clamp, UTF-8 truncation).
- `npm run lint` + `npm run build` green.
- Live smoke test: burst then 429; healthz 200 while throttled; `page=99999999` clamped; forwarded client gets its own bucket.