### PR TITLE
web: support Cloudflare managed search challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,23 @@ real_ip_header CF-Connecting-IP;
 
 直连绕过 CF 的流量不在信任网段内，`CF-Connecting-IP` 伪造无效，仍按对端真实地址限流。CF 网段偶有更新，建议定期比对官方列表。
 
+### Cloudflare Bot Challenge
+
+生产站点可在 Cloudflare WAF Custom Rules 中对公开搜索页启用
+**Managed Challenge**，让可疑客户端在请求到达 Next.js 和 Go 后端前完成验证：
+
+```text
+http.host eq "search.example.com" and
+http.request.uri.path eq "/search" and
+not cf.client.bot
+```
+
+把这条规则放在任何 `skip` 规则之前。搜索表单和翻页链接使用完整文档导航，
+而不是 Next.js 客户端路由；Cloudflare 的 interstitial challenge 是 HTML 页面，
+若它落进 RSC/fetch 请求，浏览器无法正常展示。验证通过后 Cloudflare 用
+`cf_clearance` cookie 放行后续搜索。若 Go API 也直接暴露在公网，还应把公开
+API 搜索路径加入同一防护规则；仅监听回环地址时则不需要。
+
 ## 过滤策略
 
 ### 第一道：入库前的静态过滤

--- a/web/components/Pagination.tsx
+++ b/web/components/Pagination.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Link from "next/link";
+import type { MouseEvent } from "react";
 
 interface PaginationProps {
   q: string;
@@ -16,11 +19,20 @@ export default function Pagination({ q, page, total, pageSize }: PaginationProps
     "rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 text-sm text-zinc-300 transition-colors hover:border-emerald-600 hover:text-emerald-400";
   const disabledCls =
     "cursor-not-allowed rounded-md border border-zinc-800 bg-zinc-900 px-4 py-2 text-sm text-zinc-600";
+  const navigate = (event: MouseEvent<HTMLAnchorElement>, href: string) => {
+    event.preventDefault();
+    window.location.assign(href);
+  };
 
   return (
     <nav className="mt-6 flex items-center justify-center gap-4">
       {page > 1 ? (
-        <Link href={mkHref(page - 1)} className={btnCls}>
+        <Link
+          href={mkHref(page - 1)}
+          className={btnCls}
+          prefetch={false}
+          onClick={(event) => navigate(event, mkHref(page - 1))}
+        >
           ← 上一页
         </Link>
       ) : (
@@ -30,7 +42,12 @@ export default function Pagination({ q, page, total, pageSize }: PaginationProps
         第 {page} / {totalPages} 页
       </span>
       {page < totalPages ? (
-        <Link href={mkHref(page + 1)} className={btnCls}>
+        <Link
+          href={mkHref(page + 1)}
+          className={btnCls}
+          prefetch={false}
+          onClick={(event) => navigate(event, mkHref(page + 1))}
+        >
           下一页 →
         </Link>
       ) : (

--- a/web/components/SearchBox.tsx
+++ b/web/components/SearchBox.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { FormEvent, useState } from "react";
 
 interface SearchBoxProps {
@@ -9,13 +8,18 @@ interface SearchBoxProps {
 }
 
 export default function SearchBox({ initialQuery = "", large = false }: SearchBoxProps) {
-  const router = useRouter();
   const [q, setQ] = useState(initialQuery);
 
   function onSubmit(e: FormEvent) {
     e.preventDefault();
     const query = q.trim();
-    router.push(query ? `/search?q=${encodeURIComponent(query)}` : "/search");
+    // Cloudflare may return an interstitial Managed Challenge for /search.
+    // A client-side router fetch cannot display that HTML challenge, so make
+    // search a document navigation and let Cloudflare complete its normal
+    // challenge -> cf_clearance -> page flow.
+    window.location.assign(
+      query ? `/search?q=${encodeURIComponent(query)}` : "/search",
+    );
   }
 
   return (


### PR DESCRIPTION
## What changed

- make search form submissions use full document navigation
- make pagination use full document navigation and disable Next.js prefetch
- document the Cloudflare Managed Challenge rule, rule ordering, and private-API considerations

## Why

Cloudflare interstitial challenges are HTML documents. When `/search` is reached through Next.js client routing, that challenge can land inside an RSC/fetch request and cannot be displayed to the visitor. Full document navigation lets Cloudflare complete the normal challenge → `cf_clearance` → search-page flow.

The production WAF rule is already active for `bt.maxlv.net/search`, placed before the existing skip rule. The Go API remains private on loopback, so it does not need a second public challenge rule.

## User impact

Visitors may see Cloudflare's Managed Challenge before their first search. Once cleared, search and pagination work normally. Verified bots are exempted by the WAF expression.

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `gofmt -l .`
- `go vet ./...`
- `go test ./...`
- production deployment health check: API and web services active
- public smoke test: `/search` returns `403` with `cf-mitigated: challenge`; `/` remains `200`
- repository, diff, and Git-history credential scans clean