### PR TITLE
server: rank fetch queue by tracker-scraped seeder count

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ infohash 来自两条路径，**主动的那条决定吞吐**：
 
 最后一条最反直觉：找 peer 本身就占掉大部分等待时间，**能成功的获取本来就是慢的那些**，缩超时等于把它们全砍掉。换硬件请照着 `/api/stats` 重新测，别照抄。
 
+### Tracker 刮削排序
+
+既然 99% 的发现结果注定被丢弃，**丢谁**就决定了索引长成什么样。默认开启的
+scraper（`SCRAPE_ENABLED`）在爬虫和获取端之间插了一层：把新发现的 infohash 攒成
+批（一个 UDP 包最多问 ~70 个），向几个大型公共 tracker 发 BEP 15 scrape 拿到
+seeder 数，然后按 seeder 数从高到低喂给获取端——热门资源（多为影视内容）优先，
+0 seeder 的只是排队靠后，不会被直接扔掉；队列满了先踢 seeder 最少的，等价于把
+原来的「随机丢」换成「有依据地丢」。热门资源 peer 多，获取成功率也更高，排序本
+身就在提升吞吐。
+
+同一份 `TRACKERS` 列表还会以 `&tr=` 附在获取端的磁力链接上：tracker 一次往返就
+能拿到 peer 列表，省掉吃掉大半 `META_TIMEOUT` 的 DHT 找 peer 游走。
+
+看 `/api/stats` 的 `scraper` 段：`seeded/scraped` 是命中率（有 seeder 的占比），
+`queue` 是排队深度，`evicted` 是被挤掉的低优先级 hash，`scrape_errors` 持续增长
+说明某个 tracker 挂了（自动重连，也可换 `TRACKERS`）。
+
 ## 快速开始
 
 ### 后端

--- a/env.example
+++ b/env.example
@@ -53,6 +53,22 @@ META_WORKERS=128
 # fell to 2.4/min.
 # META_TIMEOUT=45s
 
+# --- Tracker scrape ranking ---
+# Discovery finds ~20x more infohashes than the fetch pool can consume, so
+# WHICH hashes get a fetch slot decides what the index grows into. When
+# enabled, every discovered hash is scraped against the trackers below
+# (BEP 15: seeder counts for ~70 hashes per UDP packet) and the fetch queue
+# is ordered by seeder count — popular content first — instead of dropping
+# the overflow at random. Zero-seeder hashes are only deprioritized, not
+# discarded. Watch /api/stats "scraper": seeded/scraped is the hit rate;
+# evicted is what used to be silent random drops.
+SCRAPE_ENABLED=true
+# Comma-separated announce URLs. Also appended to fetch magnets as &tr= peer
+# hints, which shortcuts the DHT peer walk that eats most of META_TIMEOUT.
+# Only udp:// entries can be scraped; keep to the big open trackers that are
+# built for this volume.
+# TRACKERS=udp://tracker.opentrackr.org:1337/announce,udp://open.demonii.com:1337/announce,udp://tracker.torrent.eu.org:451/announce,udp://exodus.desync.com:6969/announce
+
 # --- Indexing ---
 # Skip torrents whose total size is below this many bytes (default 100 MiB).
 MIN_TORRENT_SIZE=104857600

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -19,8 +20,17 @@ import (
 	"dhtsearch/server/internal/filter"
 	"dhtsearch/server/internal/metadata"
 	"dhtsearch/server/internal/moderator"
+	"dhtsearch/server/internal/scraper"
 	"dhtsearch/server/internal/store"
 )
+
+// defaultTrackers are large, long-lived open trackers. They serve both
+// pipeline roles (scrape ranking and magnet peer hints); the list is
+// overridable via TRACKERS for when one of them inevitably goes away.
+const defaultTrackers = "udp://tracker.opentrackr.org:1337/announce," +
+	"udp://open.demonii.com:1337/announce," +
+	"udp://tracker.torrent.eu.org:451/announce," +
+	"udp://exodus.desync.com:6969/announce"
 
 // envDefault returns the env value or fallback.
 func envDefault(key, fallback string) string {
@@ -57,6 +67,37 @@ func envInt64(key string, fallback int64) int64 {
 	return fallback
 }
 
+// splitCSV splits a comma-separated list, trimming whitespace and dropping
+// empty entries.
+func splitCSV(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// scraperStatus adapts the scraper's stats for the API; nil scraper (scrape
+// disabled, crawler off, or bare-infohash mode) means no stats section.
+func scraperStatus(scr *scraper.Scraper) func() api.ScraperStatus {
+	if scr == nil {
+		return nil
+	}
+	return func() api.ScraperStatus {
+		ss := scr.Stats()
+		return api.ScraperStatus{
+			Queue:      ss.QueueLen,
+			Scraped:    ss.Scraped,
+			Seeded:     ss.Seeded,
+			ScrapeErrs: ss.ScrapeErrs,
+			Dropped:    ss.Dropped,
+			Evicted:    ss.Evicted,
+		}
+	}
+}
+
 func envFloat(key string, fallback float64) float64 {
 	if v := os.Getenv(key); v != "" {
 		if f, err := strconv.ParseFloat(v, 64); err == nil {
@@ -84,6 +125,10 @@ func main() {
 	metaWorkers := flag.Int("meta-workers", envInt("META_WORKERS", 128), "metadata fetch worker count")
 	metaTimeout := flag.Duration("meta-timeout", envDuration("META_TIMEOUT", 45*time.Second), "metadata fetch timeout per torrent")
 	fetchMetadata := flag.Bool("fetch-metadata", envBool("FETCH_METADATA", true), "fetch torrent metadata (false: store bare infohashes)")
+	trackersCSV := flag.String("trackers", envDefault("TRACKERS", defaultTrackers),
+		"comma-separated tracker announce URLs, used both to rank discovered infohashes (BEP 15 scrape) and as peer hints on fetch magnets (empty = neither)")
+	scrapeEnabled := flag.Bool("scrape", envBool("SCRAPE_ENABLED", true),
+		"rank discovered infohashes by tracker-scraped seeder count before fetching")
 	seedDemo := flag.Bool("seed-demo", false, "insert demo records at startup")
 	minSize := flag.Int64("min-size", envInt64("MIN_TORRENT_SIZE", 100<<20),
 		"skip torrents whose total size is below this many bytes")
@@ -144,20 +189,38 @@ func main() {
 	}
 	defer cr.Close()
 
-	// Pipeline: infohashes -> metadata -> filter -> store.
+	trackerList := splitCSV(*trackersCSV)
+
+	// Pipeline: infohashes -> scrape ranking -> metadata -> filter -> store.
 	var fetcher *metadata.Fetcher
+	var scr *scraper.Scraper
 	if *fetchMetadata {
 		var err error
 		fetcher, err = metadata.NewFetcher(metadata.Config{
-			Workers: *metaWorkers,
-			Timeout: *metaTimeout,
-			Logger:  logger,
+			Workers:  *metaWorkers,
+			Timeout:  *metaTimeout,
+			Trackers: trackerList,
+			Logger:   logger,
 		})
 		if err != nil {
 			logger.Fatalf("metadata: %v", err)
 		}
 		defer fetcher.Close()
-		fetcher.Run(ctx, cr.Infohashes(), func(rec metadata.Record) {
+		feed := cr.Infohashes()
+		if *scrapeEnabled && len(trackerList) > 0 && feed != nil {
+			scr, err = scraper.New(scraper.Config{
+				Trackers: trackerList,
+				Logger:   logger,
+			})
+			if err != nil {
+				logger.Printf("scraper: disabled: %v", err)
+			} else {
+				defer scr.Close()
+				scr.Run(ctx, feed)
+				feed = scr.Out()
+			}
+		}
+		fetcher.Run(ctx, feed, func(rec metadata.Record) {
 			res := filter.Check(rec.Name, rec.Files, rec.TotalSize)
 			if res.Adult {
 				st.IncrStat("adult_filtered", 1)
@@ -269,6 +332,7 @@ func main() {
 			RateBurst:     *rateBurst,
 			MaxInflight:   *searchInflight,
 			SearchTimeout: *searchTimeout,
+			ScraperStatus: scraperStatus(scr),
 		}).Handler(),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       15 * time.Second,

--- a/server/internal/api/api.go
+++ b/server/internal/api/api.go
@@ -50,6 +50,8 @@ type Options struct {
 	// StatsTTL is how long stats and total-count responses are served from
 	// cache. Stats hit four aggregate queries; caching makes them O(1).
 	StatsTTL time.Duration
+	// ScraperStatus, when non-nil, adds a "scraper" section to /api/stats.
+	ScraperStatus func() ScraperStatus
 }
 
 // CrawlerStatus describes the crawler for the stats endpoint. The sampler
@@ -64,6 +66,18 @@ type CrawlerStatus struct {
 	Sampled   int64 `json:"sampled"`
 	SampleErr int64 `json:"sample_errors"`
 	Harvested int64 `json:"harvested"`
+}
+
+// ScraperStatus describes the tracker-scrape prioritizer. Seeded/Scraped is
+// the share of discovered hashes with at least one tracker-known seeder;
+// Evicted counts hashes that lost their fetch slot to better-seeded ones.
+type ScraperStatus struct {
+	Queue      int   `json:"queue"`
+	Scraped    int64 `json:"scraped"`
+	Seeded     int64 `json:"seeded"`
+	ScrapeErrs int64 `json:"scrape_errors"`
+	Dropped    int64 `json:"dropped"`
+	Evicted    int64 `json:"evicted"`
 }
 
 // Server serves the search API.
@@ -313,6 +327,9 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	}
 	if s.crawler != nil {
 		resp["crawler"] = s.crawler()
+	}
+	if s.opts.ScraperStatus != nil {
+		resp["scraper"] = s.opts.ScraperStatus()
 	}
 	body, err := json.Marshal(resp)
 	if err != nil {

--- a/server/internal/metadata/fetcher.go
+++ b/server/internal/metadata/fetcher.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,16 +35,22 @@ type Config struct {
 	Timeout time.Duration
 	// MaxFiles caps how many file entries are kept per torrent.
 	MaxFiles int
+	// Trackers are announce URLs appended to every magnet. Tracker announces
+	// return a peer list in one round trip, where a DHT get_peers walk can
+	// eat most of the fetch timeout — for well-tracked (popular) content
+	// this is the difference between fetching and timing out.
+	Trackers []string
 	// Logger, nil for log.Default().
 	Logger *log.Logger
 }
 
 // Fetcher consumes infohashes and reports successfully fetched metadata.
 type Fetcher struct {
-	cfg    Config
-	client *torrent.Client
-	tmpDir string
-	logger *log.Logger
+	cfg          Config
+	client       *torrent.Client
+	tmpDir       string
+	logger       *log.Logger
+	magnetSuffix string // pre-encoded &tr=... params, possibly empty
 
 	wg     sync.WaitGroup
 	cancel context.CancelFunc
@@ -86,7 +94,27 @@ func NewFetcher(cfg Config) (*Fetcher, error) {
 		os.RemoveAll(tmpDir)
 		return nil, fmt.Errorf("torrent client: %w", err)
 	}
-	return &Fetcher{cfg: cfg, client: client, tmpDir: tmpDir, logger: logger}, nil
+	return &Fetcher{
+		cfg:          cfg,
+		client:       client,
+		tmpDir:       tmpDir,
+		logger:       logger,
+		magnetSuffix: magnetTrackerParams(cfg.Trackers),
+	}, nil
+}
+
+// magnetTrackerParams encodes announce URLs as magnet &tr= parameters.
+func magnetTrackerParams(trackers []string) string {
+	var b strings.Builder
+	for _, tr := range trackers {
+		tr = strings.TrimSpace(tr)
+		if tr == "" {
+			continue
+		}
+		b.WriteString("&tr=")
+		b.WriteString(url.QueryEscape(tr))
+	}
+	return b.String()
 }
 
 // Run starts the worker pool consuming hex infohashes from in until in is
@@ -129,7 +157,7 @@ func (f *Fetcher) fetch(ctx context.Context, hexHash string) (Record, bool) {
 		f.count(&f.failed)
 		return rec, false
 	}
-	t, err := f.client.AddMagnet("magnet:?xt=urn:btih:" + hexHash)
+	t, err := f.client.AddMagnet("magnet:?xt=urn:btih:" + hexHash + f.magnetSuffix)
 	if err != nil {
 		f.count(&f.failed)
 		return rec, false

--- a/server/internal/scraper/scraper.go
+++ b/server/internal/scraper/scraper.go
@@ -1,0 +1,458 @@
+// Package scraper ranks discovered infohashes by swarm size before metadata
+// fetching. Discovery yields far more infohashes than the fetch pool can
+// consume, so which ones get a fetch slot decides what the index grows into.
+// A BEP 15 UDP scrape answers "how many seeders?" for up to ~70 infohashes in
+// a single packet — three orders of magnitude cheaper than a metadata fetch —
+// so every discovered hash is scraped against a few large open trackers and
+// queued by seeder count. Popular swarms (which skew toward current video
+// content) are fetched first; they are also the fetches most likely to
+// succeed, since peers are plentiful.
+//
+// Zero-seeder hashes are not discarded: they queue at priority 0 and are
+// fetched whenever nothing better is waiting, so DHT-only content still
+// trickles in. When the queue overflows, the lowest-priority entries are the
+// ones evicted — the same hashes that were previously dropped at random.
+package scraper
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"net/url"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/anacrolix/torrent/tracker/udp"
+)
+
+const (
+	defaultQueueCap  = 1 << 14
+	defaultBatchMax  = 70 // BEP 15 allows ~74 per packet; stay under
+	defaultBatchWait = 2 * time.Second
+	defaultTimeout   = 10 * time.Second
+
+	// scrapeWorkers bounds concurrent in-flight batches. Each worker mostly
+	// waits on UDP round trips, so they are cheap; the bound exists so dead
+	// trackers (every batch riding out the full timeout) shed load by
+	// dropping batches instead of queueing them without limit.
+	scrapeWorkers  = 8
+	batchQueueSize = 16
+)
+
+// Config controls the scraper.
+type Config struct {
+	// Trackers are udp:// announce URLs to scrape. Non-UDP entries are
+	// skipped (HTTP scrape exists but no large open tracker needs it here).
+	Trackers []string
+	// QueueCap bounds the priority queue; overflow evicts the lowest
+	// seeder counts first.
+	QueueCap int
+	// BatchMax is the most infohashes packed into one scrape request.
+	BatchMax int
+	// BatchWait flushes a partial batch that has waited this long.
+	BatchWait time.Duration
+	// Timeout is the budget for scraping one batch against one tracker.
+	Timeout time.Duration
+	// Logger, nil for log.Default().
+	Logger *log.Logger
+}
+
+// Stats is a snapshot of scraper activity for the stats endpoint.
+type Stats struct {
+	QueueLen   int   // hashes waiting for a fetch slot
+	Scraped    int64 // hashes scraped so far
+	Seeded     int64 // of those, hashes with at least one seeder
+	ScrapeErrs int64 // failed tracker requests (per tracker, per batch)
+	Dropped    int64 // hashes dropped because all scrape workers were busy
+	Evicted    int64 // hashes evicted from a full queue
+}
+
+type item struct {
+	hash    string
+	seeders int32
+}
+
+// trackerConn owns the UDP client for one tracker, recreating it after a
+// failure (the conn client closes itself on read errors).
+type trackerConn struct {
+	host string // "host:port"
+	mu   sync.Mutex
+	cc   *udp.ConnClient
+}
+
+// Scraper consumes discovered infohashes, scrapes them and re-emits them in
+// descending seeder order.
+type Scraper struct {
+	cfg      Config
+	trackers []*trackerConn
+	logger   *log.Logger
+
+	out      chan string
+	wake     chan struct{}
+	feedDone chan struct{} // closed once nothing can enqueue anymore
+
+	mu      sync.Mutex
+	pending []item // sorted by seeders descending; FIFO among equals
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	scraped    atomic.Int64
+	seeded     atomic.Int64
+	scrapeErrs atomic.Int64
+	dropped    atomic.Int64
+	evicted    atomic.Int64
+
+	// scrapeTracker is swapped in tests to avoid network I/O.
+	scrapeTracker func(ctx context.Context, tc *trackerConn, ihs [][20]byte) ([]int32, error)
+}
+
+// New validates the tracker list and builds a scraper. At least one valid
+// udp:// tracker is required.
+func New(cfg Config) (*Scraper, error) {
+	if cfg.QueueCap <= 0 {
+		cfg.QueueCap = defaultQueueCap
+	}
+	if cfg.BatchMax <= 0 || cfg.BatchMax > defaultBatchMax {
+		cfg.BatchMax = defaultBatchMax
+	}
+	if cfg.BatchWait <= 0 {
+		cfg.BatchWait = defaultBatchWait
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultTimeout
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = log.Default()
+	}
+	s := &Scraper{
+		cfg:           cfg,
+		logger:        logger,
+		out:           make(chan string),
+		wake:          make(chan struct{}, 1),
+		feedDone:      make(chan struct{}),
+		scrapeTracker: realScrape,
+	}
+	for _, raw := range cfg.Trackers {
+		host, err := trackerHost(raw)
+		if err != nil {
+			logger.Printf("scraper: skipping tracker %q: %v", raw, err)
+			continue
+		}
+		s.trackers = append(s.trackers, &trackerConn{host: host})
+	}
+	if len(s.trackers) == 0 {
+		return nil, fmt.Errorf("no scrapeable udp trackers in %v", cfg.Trackers)
+	}
+	return s, nil
+}
+
+// trackerHost extracts "host:port" from a udp:// announce URL.
+func trackerHost(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme != "udp" {
+		return "", fmt.Errorf("scheme %q is not scrapeable over BEP 15", u.Scheme)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("no host")
+	}
+	return u.Host, nil
+}
+
+// Run starts the pipeline consuming hex infohashes from in. The reordered
+// hashes are delivered on Out, which closes when in closes or the scraper is
+// closed.
+func (s *Scraper) Run(ctx context.Context, in <-chan string) {
+	ctx, s.cancel = context.WithCancel(ctx)
+	batches := make(chan []string, batchQueueSize)
+	var feedWG sync.WaitGroup
+	feedWG.Add(1)
+	go s.collect(ctx, in, batches, &feedWG)
+	for i := 0; i < scrapeWorkers; i++ {
+		feedWG.Add(1)
+		go s.scrapeWorker(ctx, batches, &feedWG)
+	}
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		feedWG.Wait()
+		close(s.feedDone)
+	}()
+	s.wg.Add(1)
+	go s.pushLoop(ctx)
+	s.logger.Printf("scraper: ranking infohashes via %d trackers", len(s.trackers))
+}
+
+// Out returns the channel of prioritized hex infohashes.
+func (s *Scraper) Out() <-chan string { return s.out }
+
+// Stats returns a snapshot of the counters.
+func (s *Scraper) Stats() Stats {
+	s.mu.Lock()
+	qlen := len(s.pending)
+	s.mu.Unlock()
+	return Stats{
+		QueueLen:   qlen,
+		Scraped:    s.scraped.Load(),
+		Seeded:     s.seeded.Load(),
+		ScrapeErrs: s.scrapeErrs.Load(),
+		Dropped:    s.dropped.Load(),
+		Evicted:    s.evicted.Load(),
+	}
+}
+
+// Close stops the pipeline and closes tracker connections.
+func (s *Scraper) Close() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	s.wg.Wait()
+	for _, tc := range s.trackers {
+		tc.mu.Lock()
+		if tc.cc != nil {
+			tc.cc.Close()
+			tc.cc = nil
+		}
+		tc.mu.Unlock()
+	}
+}
+
+// collect batches incoming hashes for scraping. It always keeps draining in:
+// if the scrape workers are saturated, a batch is dropped rather than letting
+// backpressure reach the crawler's non-blocking push.
+func (s *Scraper) collect(ctx context.Context, in <-chan string, batches chan<- []string, wg *sync.WaitGroup) {
+	defer wg.Done()
+	defer close(batches)
+	var batch []string
+	timer := time.NewTimer(s.cfg.BatchWait)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		select {
+		case batches <- batch:
+		default:
+			s.dropped.Add(int64(len(batch)))
+		}
+		batch = nil
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case h, ok := <-in:
+			if !ok {
+				flush()
+				return
+			}
+			if len(batch) == 0 {
+				timer.Reset(s.cfg.BatchWait)
+			}
+			batch = append(batch, h)
+			if len(batch) >= s.cfg.BatchMax {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				flush()
+			}
+		case <-timer.C:
+			flush()
+		}
+	}
+}
+
+func (s *Scraper) scrapeWorker(ctx context.Context, batches <-chan []string, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case batch, ok := <-batches:
+			if !ok {
+				return
+			}
+			s.scrapeBatch(ctx, batch)
+		}
+	}
+}
+
+// scrapeBatch queries every tracker in parallel and enqueues each hash with
+// the highest seeder count any tracker reported. A hash unknown everywhere
+// (or a batch where every tracker errored) enqueues at zero — deprioritized,
+// not lost.
+func (s *Scraper) scrapeBatch(ctx context.Context, hexes []string) {
+	ihs := make([][20]byte, 0, len(hexes))
+	kept := make([]string, 0, len(hexes))
+	for _, h := range hexes {
+		b, err := hex.DecodeString(h)
+		if err != nil || len(b) != 20 {
+			continue
+		}
+		var ih [20]byte
+		copy(ih[:], b)
+		ihs = append(ihs, ih)
+		kept = append(kept, h)
+	}
+	if len(ihs) == 0 {
+		return
+	}
+	best := make([]int32, len(ihs))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, tc := range s.trackers {
+		wg.Add(1)
+		go func(tc *trackerConn) {
+			defer wg.Done()
+			sctx, cancel := context.WithTimeout(ctx, s.cfg.Timeout)
+			defer cancel()
+			res, err := s.scrapeTracker(sctx, tc, ihs)
+			if err != nil {
+				s.scrapeErrs.Add(1)
+				return
+			}
+			mu.Lock()
+			for i, n := range res {
+				if i < len(best) && n > best[i] {
+					best[i] = n
+				}
+			}
+			mu.Unlock()
+		}(tc)
+	}
+	wg.Wait()
+
+	items := make([]item, len(kept))
+	var seededN int64
+	for i, h := range kept {
+		if best[i] > 0 {
+			seededN++
+		}
+		items[i] = item{hash: h, seeders: best[i]}
+	}
+	s.scraped.Add(int64(len(kept)))
+	s.seeded.Add(seededN)
+	s.enqueue(items)
+}
+
+// enqueue merges a scraped batch into the priority queue. Sorting the whole
+// slice per batch is deliberate: batches arrive every second or two and the
+// queue is a few thousand entries, so a stable sort is both fast enough and
+// gives FIFO order among equal seeder counts for free.
+func (s *Scraper) enqueue(items []item) {
+	s.mu.Lock()
+	s.pending = append(s.pending, items...)
+	sort.SliceStable(s.pending, func(i, j int) bool {
+		return s.pending[i].seeders > s.pending[j].seeders
+	})
+	if n := len(s.pending); n > s.cfg.QueueCap {
+		s.evicted.Add(int64(n - s.cfg.QueueCap))
+		s.pending = append([]item(nil), s.pending[:s.cfg.QueueCap]...)
+	}
+	s.mu.Unlock()
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+}
+
+// pushLoop feeds the fetcher the current best hash, blocking on the
+// unbuffered out channel so priority is applied as late as possible. It
+// closes out once the queue is empty and nothing upstream can refill it,
+// mirroring how the crawler's channel closes on shutdown.
+func (s *Scraper) pushLoop(ctx context.Context) {
+	defer s.wg.Done()
+	defer close(s.out)
+	for {
+		s.mu.Lock()
+		var next string
+		ok := len(s.pending) > 0
+		if ok {
+			next = s.pending[0].hash
+			s.pending = s.pending[1:]
+		}
+		s.mu.Unlock()
+		if !ok {
+			select {
+			case <-ctx.Done():
+				return
+			case <-s.wake:
+				continue
+			case <-s.feedDone:
+			}
+			// Every enqueue happens before feedDone closes, so an empty
+			// queue seen after this point is final.
+			s.mu.Lock()
+			empty := len(s.pending) == 0
+			s.mu.Unlock()
+			if empty {
+				return
+			}
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case s.out <- next:
+		}
+	}
+}
+
+// realScrape performs one BEP 15 scrape. BEP 15 defines the response as one
+// result per requested infohash, in request order, so alignment is by index.
+func realScrape(ctx context.Context, tc *trackerConn, ihs [][20]byte) ([]int32, error) {
+	cc, err := tc.conn()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := cc.Client.Scrape(ctx, ihs)
+	if err != nil {
+		tc.reset(cc)
+		return nil, err
+	}
+	if len(resp) > len(ihs) {
+		resp = resp[:len(ihs)]
+	}
+	out := make([]int32, len(resp))
+	for i, r := range resp {
+		out[i] = r.Seeders
+	}
+	return out, nil
+}
+
+func (tc *trackerConn) conn() (*udp.ConnClient, error) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	if tc.cc != nil {
+		return tc.cc, nil
+	}
+	cc, err := udp.NewConnClient(udp.NewConnClientOpts{Network: "udp", Host: tc.host})
+	if err != nil {
+		return nil, err
+	}
+	tc.cc = cc
+	return cc, nil
+}
+
+// reset drops the connection that just failed so the next scrape redials,
+// unless another goroutine already replaced it.
+func (tc *trackerConn) reset(old *udp.ConnClient) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	if tc.cc == old {
+		old.Close()
+		tc.cc = nil
+	}
+}

--- a/server/internal/scraper/scraper_test.go
+++ b/server/internal/scraper/scraper_test.go
@@ -1,0 +1,211 @@
+package scraper
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"testing"
+	"time"
+)
+
+// hashN builds a valid distinct hex infohash from n.
+func hashN(n byte) string {
+	var ih [20]byte
+	ih[0] = n
+	ih[19] = 1 // never the all-zero hash
+	return hex.EncodeToString(ih[:])
+}
+
+func quietLogger() *log.Logger { return log.New(io.Discard, "", 0) }
+
+// fakeSeeders installs a scrape stub that reports seeders[hash] for known
+// hashes and 0 otherwise.
+func fakeSeeders(s *Scraper, seeders map[string]int32) {
+	s.scrapeTracker = func(_ context.Context, _ *trackerConn, ihs [][20]byte) ([]int32, error) {
+		out := make([]int32, len(ihs))
+		for i, ih := range ihs {
+			out[i] = seeders[hex.EncodeToString(ih[:])]
+		}
+		return out, nil
+	}
+}
+
+func recvOrFail(t *testing.T, ch <-chan string) string {
+	t.Helper()
+	select {
+	case h := <-ch:
+		return h
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for a prioritized hash")
+		return ""
+	}
+}
+
+func TestNewRejectsUnusableTrackers(t *testing.T) {
+	_, err := New(Config{
+		Trackers: []string{"https://tracker.example/announce", "not a url at all", "udp://"},
+		Logger:   quietLogger(),
+	})
+	if err == nil {
+		t.Fatal("want error when no tracker is scrapeable")
+	}
+}
+
+func TestTrackerHost(t *testing.T) {
+	host, err := trackerHost("udp://tracker.opentrackr.org:1337/announce")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if host != "tracker.opentrackr.org:1337" {
+		t.Fatalf("host = %q", host)
+	}
+	if _, err := trackerHost("http://tracker.example/announce"); err == nil {
+		t.Fatal("want error for non-udp scheme")
+	}
+}
+
+func TestPrioritizesBySeeders(t *testing.T) {
+	s, err := New(Config{
+		Trackers: []string{"udp://tracker.invalid:1337/announce"},
+		BatchMax: 4,
+		Logger:   quietLogger(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	low, mid, high, zero := hashN(1), hashN(2), hashN(3), hashN(4)
+	fakeSeeders(s, map[string]int32{low: 2, mid: 40, high: 900})
+
+	in := make(chan string, 4)
+	for _, h := range []string{zero, low, high, mid} { // one full batch
+		in <- h
+	}
+	s.Run(context.Background(), in)
+	defer s.Close()
+
+	want := []string{high, mid, low, zero}
+	for i, w := range want {
+		if got := recvOrFail(t, s.Out()); got != w {
+			t.Fatalf("position %d: got %s want %s", i, got, w)
+		}
+	}
+	st := s.Stats()
+	if st.Scraped != 4 || st.Seeded != 3 {
+		t.Fatalf("stats = %+v, want Scraped=4 Seeded=3", st)
+	}
+}
+
+func TestQueueEvictsLowestPriority(t *testing.T) {
+	s, err := New(Config{
+		Trackers: []string{"udp://tracker.invalid:1337/announce"},
+		BatchMax: 4,
+		QueueCap: 2,
+		Logger:   quietLogger(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h1, h2, h3, h4 := hashN(1), hashN(2), hashN(3), hashN(4)
+	fakeSeeders(s, map[string]int32{h1: 9, h2: 7, h3: 5, h4: 3})
+
+	in := make(chan string, 4)
+	for _, h := range []string{h4, h2, h1, h3} { // one full batch
+		in <- h
+	}
+	close(in) // out closes once everything surviving has been delivered
+	s.Run(context.Background(), in)
+	defer s.Close()
+
+	// The batch lands in the queue atomically, so the cap keeps the top two.
+	var got []string
+	for h := range s.Out() {
+		got = append(got, h)
+	}
+	want := []string{h1, h2}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("delivered %v, want %v", got, want)
+	}
+	if ev := s.Stats().Evicted; ev != 2 {
+		t.Fatalf("Evicted = %d, want 2", ev)
+	}
+}
+
+func TestPartialBatchFlushesOnTimer(t *testing.T) {
+	s, err := New(Config{
+		Trackers:  []string{"udp://tracker.invalid:1337/announce"},
+		BatchMax:  70,
+		BatchWait: 50 * time.Millisecond,
+		Logger:    quietLogger(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := hashN(7)
+	fakeSeeders(s, map[string]int32{h: 1})
+
+	in := make(chan string, 1)
+	in <- h
+	s.Run(context.Background(), in)
+	defer s.Close()
+
+	if got := recvOrFail(t, s.Out()); got != h {
+		t.Fatalf("got %s want %s", got, h)
+	}
+}
+
+func TestAllTrackersFailingStillDelivers(t *testing.T) {
+	s, err := New(Config{
+		Trackers: []string{"udp://tracker.invalid:1337/announce"},
+		BatchMax: 2,
+		Logger:   quietLogger(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.scrapeTracker = func(context.Context, *trackerConn, [][20]byte) ([]int32, error) {
+		return nil, fmt.Errorf("tracker down")
+	}
+	h1, h2 := hashN(1), hashN(2)
+	in := make(chan string, 2)
+	in <- h1
+	in <- h2
+	s.Run(context.Background(), in)
+	defer s.Close()
+
+	got := map[string]bool{recvOrFail(t, s.Out()): true, recvOrFail(t, s.Out()): true}
+	if !got[h1] || !got[h2] {
+		t.Fatalf("delivered %v, want both %s and %s", got, h1, h2)
+	}
+	if errs := s.Stats().ScrapeErrs; errs == 0 {
+		t.Fatal("want ScrapeErrs > 0")
+	}
+}
+
+func TestMalformedHashesAreSkipped(t *testing.T) {
+	s, err := New(Config{
+		Trackers: []string{"udp://tracker.invalid:1337/announce"},
+		BatchMax: 3,
+		Logger:   quietLogger(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	good := hashN(5)
+	fakeSeeders(s, map[string]int32{good: 3})
+
+	in := make(chan string, 3)
+	in <- "zzzz"     // not hex
+	in <- "deadbeef" // wrong length
+	in <- good
+	s.Run(context.Background(), in)
+	defer s.Close()
+
+	if got := recvOrFail(t, s.Out()); got != good {
+		t.Fatalf("got %s want %s", got, good)
+	}
+	if st := s.Stats(); st.Scraped != 1 {
+		t.Fatalf("Scraped = %d, want 1 (malformed skipped)", st.Scraped)
+	}
+}


### PR DESCRIPTION
## What

Inserts a tracker-scrape prioritization stage between DHT discovery and metadata fetching, and adds tracker peer hints to fetch magnets.

## Why

Discovery digs up ~3000 infohashes/min while the fetch pool consumes ~130 — 99% are dropped **at random**. Which hashes get a fetch slot decides what the index grows into. A BEP 15 UDP scrape answers "how many seeders?" for ~70 hashes in a single packet, three orders of magnitude cheaper than a metadata fetch, so we can afford to scrape everything we discover and drop *with evidence* instead of blindly.

## How

- **`internal/scraper`** (new): batches discovered hashes (≤70, 2s flush), scrapes them against 4 large open trackers in parallel, and re-emits hashes in descending seeder order from a bounded priority queue (16k; overflow evicts lowest seeders first). Zero-seeder hashes queue at priority 0 — deprioritized, never discarded, so DHT-only content still trickles in. Tracker connections redial after failures; if every tracker errors, the batch passes through unranked rather than stalling the pipeline.
- **`internal/metadata`**: fetch magnets now carry the tracker list as `&tr=` params. Tracker announces return peers in one round trip, where the DHT get_peers walk eats most of `META_TIMEOUT` (per the README's own measurements, peer-finding dominates fetch latency).
- **`/api/stats`**: new `scraper` section — `queue`, `scraped`, `seeded` (hit rate numerator), `scrape_errors`, `dropped`, `evicted`.
- **Config**: `SCRAPE_ENABLED` (default on), `TRACKERS` (default: opentrackr, demonii, torrent.eu.org, exodus.desync.com). Documented in `env.example` and README.

## Expected effect

Popular swarms (which skew heavily toward current film/TV) get fetched first *and* succeed most often since peers are plentiful — the bias compounds throughput instead of costing it. Watch `seeded/scraped` and per-minute upserts on `/api/stats` after deploy to quantify.

## Testing

- `gofmt`, `go vet ./...`, `go test ./...` all pass; scraper tests also run under `-race`.
- New unit tests cover priority ordering, queue eviction, partial-batch timer flush, all-trackers-down passthrough, and malformed-hash skipping (scrape I/O stubbed).