### PR TITLE
web: support selecting multiple results and batch-copying magnet links

### DIFF
--- a/web/app/search/page.tsx
+++ b/web/app/search/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { fetchSearch, type SearchResponse } from "@/lib/api";
 import { formatCount } from "@/lib/format";
 import SearchBox from "@/components/SearchBox";
-import ResultCard from "@/components/ResultCard";
+import ResultList from "@/components/ResultList";
 import Pagination from "@/components/Pagination";
 
 interface PageProps {
@@ -68,11 +68,7 @@ export default async function SearchPage({ searchParams }: PageProps) {
               <>最新收录 · 共 {formatCount(data.total)} 条</>
             )}
           </p>
-          <div className="mt-3 space-y-3">
-            {data.results.map((r) => (
-              <ResultCard key={r.info_hash} result={r} />
-            ))}
-          </div>
+          <ResultList results={data.results} />
           <Pagination q={q} page={data.page ?? page} total={data.total ?? 0} pageSize={data.page_size ?? pageSize} />
         </>
       ) : (

--- a/web/components/CopyMagnetButton.tsx
+++ b/web/components/CopyMagnetButton.tsx
@@ -1,22 +1,13 @@
 "use client";
 
 import { useState } from "react";
+import { copyText } from "@/lib/clipboard";
 
 export default function CopyMagnetButton({ magnet }: { magnet: string }) {
   const [copied, setCopied] = useState(false);
 
   async function copy() {
-    try {
-      await navigator.clipboard.writeText(magnet);
-    } catch {
-      // Fallback for older browsers / non-secure contexts
-      const ta = document.createElement("textarea");
-      ta.value = magnet;
-      document.body.appendChild(ta);
-      ta.select();
-      document.execCommand("copy");
-      document.body.removeChild(ta);
-    }
+    await copyText(magnet);
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   }

--- a/web/components/ResultCard.tsx
+++ b/web/components/ResultCard.tsx
@@ -13,7 +13,15 @@ import CopyMagnetButton from "./CopyMagnetButton";
 
 const MAX_FILES_SHOWN = 10;
 
-export default function ResultCard({ result }: { result: SearchResult }) {
+export default function ResultCard({
+  result,
+  selected,
+  onToggleSelect,
+}: {
+  result: SearchResult;
+  selected: boolean;
+  onToggleSelect: () => void;
+}) {
   const [expanded, setExpanded] = useState(false);
   const files = result.files ?? [];
   const shownFiles = files.slice(0, MAX_FILES_SHOWN);
@@ -27,8 +35,23 @@ export default function ResultCard({ result }: { result: SearchResult }) {
   const root = commonDirPrefix(files.map((f) => f.path));
 
   return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-900/60 p-4 transition-colors hover:border-zinc-700">
+    <div
+      className={`rounded-lg border bg-zinc-900/60 p-4 transition-colors ${
+        selected
+          ? "border-emerald-700/70 bg-emerald-950/20"
+          : "border-zinc-800 hover:border-zinc-700"
+      }`}
+    >
       <div className="flex items-start justify-between gap-3">
+        {/* Native checkbox for free keyboard/screen-reader semantics; mt-1
+            lines it up with the first line of the title. */}
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={onToggleSelect}
+          aria-label={`选择 ${result.name || "(未命名)"}`}
+          className="mt-1 h-4 w-4 shrink-0 cursor-pointer accent-emerald-500"
+        />
         <button
           onClick={() => setExpanded((v) => !v)}
           className="min-w-0 flex-1 text-left"

--- a/web/components/ResultList.tsx
+++ b/web/components/ResultList.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+import type { SearchResult } from "@/lib/api";
+import { copyText } from "@/lib/clipboard";
+import ResultCard from "./ResultCard";
+
+export default function ResultList({ results }: { results: SearchResult[] }) {
+  const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
+  const [copied, setCopied] = useState(false);
+
+  // Results can repeat an info_hash across pages but not within one, so the
+  // hash is a safe selection key for this list.
+  function toggle(infoHash: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(infoHash)) {
+        next.delete(infoHash);
+      } else {
+        next.add(infoHash);
+      }
+      return next;
+    });
+    setCopied(false);
+  }
+
+  const allSelected = selected.size === results.length;
+
+  function toggleAll() {
+    setSelected(allSelected ? new Set() : new Set(results.map((r) => r.info_hash)));
+    setCopied(false);
+  }
+
+  async function copySelected() {
+    const magnets = results
+      .filter((r) => selected.has(r.info_hash))
+      .map((r) => r.magnet);
+    if (magnets.length === 0) return;
+    await copyText(magnets.join("\n"));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <>
+      <div className="mt-3 space-y-3">
+        {results.map((r) => (
+          <ResultCard
+            key={r.info_hash}
+            result={r}
+            selected={selected.has(r.info_hash)}
+            onToggleSelect={() => toggle(r.info_hash)}
+          />
+        ))}
+      </div>
+
+      {selected.size > 0 && (
+        <div className="fixed inset-x-0 bottom-4 z-10 px-4">
+          <div className="mx-auto flex w-full max-w-3xl items-center justify-between gap-3 rounded-lg border border-zinc-700 bg-zinc-900/95 px-4 py-3 shadow-lg shadow-black/40 backdrop-blur">
+            <span className="text-sm text-zinc-300">
+              已选 <span className="font-medium text-emerald-400">{selected.size}</span> 条
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={toggleAll}
+                className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-300 transition-colors hover:border-emerald-600 hover:text-emerald-400"
+              >
+                {allSelected ? "取消全选" : "全选本页"}
+              </button>
+              <button
+                onClick={copySelected}
+                className={`rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${
+                  copied
+                    ? "border-emerald-600 bg-emerald-600/20 text-emerald-400"
+                    : "border-emerald-700 bg-emerald-600/10 text-emerald-400 hover:bg-emerald-600/20"
+                }`}
+              >
+                {copied ? "✓ 已复制" : "复制磁力链接"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/lib/clipboard.ts
+++ b/web/lib/clipboard.ts
@@ -1,0 +1,13 @@
+export async function copyText(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    // Fallback for older browsers / non-secure contexts
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand("copy");
+    document.body.removeChild(ta);
+  }
+}


### PR DESCRIPTION
## Summary
- Add a checkbox to each search result card; selected cards are highlighted with an emerald border.
- When at least one result is selected, a floating bar appears at the bottom with **全选本页 / 取消全选**, a selection count, and **复制磁力链接**, which copies all selected magnet links to the clipboard separated by newlines (ready to paste into a torrent client's batch-add dialog).
- Extract the clipboard write (including the `execCommand` fallback for non-secure contexts) into `lib/clipboard.ts`, shared by the existing per-result copy button and the new batch bar.
- Move the result list into a new `ResultList` client component that owns the selection state; the search page stays a server component.

## Testing
- `npm run lint`, `npx tsc --noEmit`, and `npm run build` all pass.