### PR TITLE
web: add clear-selection button to the selection bar

### DIFF
--- a/web/components/ResultList.tsx
+++ b/web/components/ResultList.tsx
@@ -31,6 +31,11 @@ export default function ResultList({ results }: { results: SearchResult[] }) {
     setCopied(false);
   }
 
+  function clearSelection() {
+    setSelected(new Set());
+    setCopied(false);
+  }
+
   async function copySelected() {
     const magnets = results
       .filter((r) => selected.has(r.info_hash))
@@ -90,6 +95,24 @@ export default function ResultList({ results }: { results: SearchResult[] }) {
                     <span className="hidden sm:inline">复制磁力链接</span>
                   </>
                 )}
+              </button>
+              <button
+                onClick={clearSelection}
+                title="取消选择"
+                aria-label="取消选择"
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-zinc-700 bg-zinc-800 text-zinc-400 transition-colors hover:border-zinc-500 hover:text-zinc-200 sm:h-7 sm:w-7"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  className="h-4 w-4"
+                  aria-hidden
+                >
+                  <path d="M18 6 6 18M6 6l12 12" />
+                </svg>
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Add an icon-only ✕ button (`aria-label` 取消选择) at the right end of the selection bar that empties the selection in one tap, dismissing the bar.
- Previously the only ways to exit selection mode were unchecking items one by one, or 全选本页 followed by 取消全选.

## Testing
- Verified in Chrome: select results → bar appears with ✕ → one click clears all checkboxes and dismisses the bar.
- `npm run lint`, `npx tsc --noEmit`, and `npm run build` all pass.