### PR TITLE
ci: add GitHub Actions workflow for server and web checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  server:
+    name: Go server
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
+      - name: gofmt
+        run: test -z "$(gofmt -l .)" || { gofmt -l .; exit 1; }
+      - name: go vet
+        run: go vet ./...
+      - name: go test
+        run: go test -race ./...
+
+  web:
+    name: Next.js web
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` with two jobs, mirroring the checks used locally before every push:

- **Go server**: `gofmt` (fails on unformatted files), `go vet ./...`, `go test -race ./...` — toolchain pinned via `go-version-file: server/go.mod`, module cache keyed on `go.sum`.
- **Next.js web**: `npm ci`, `npm run lint`, `npm run build` on Node 22 with npm caching. Verified locally that `next build` needs no running API (the SSR fetches are `no-store`, so those routes stay dynamic).

Triggers on pushes to `main` and on all pull requests. All commands verified passing locally, including `go test -race`.