### PR TITLE
scripts: hourly database backup to Cloudflare R2

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,30 @@ DEPLOY_HOST=user@example.com ./deploy.sh
 
 > `deploy.sh` **不会上传 `.env`**（密钥不进部署管道）。服务器上的 API key 需自行放置一次：把 `.env` 放到 `DEPLOY_DIR`（systemd 的 `WorkingDirectory`），或用 systemd 的 `EnvironmentFile=` 指向一个 root-only 的文件。缺少 key 时服务照常运行，只是 LLM 审核不启动。
 
+### 每小时备份到 Cloudflare R2
+
+`scripts/backup-r2.sh` 每小时把数据库快照上传到 R2（S3 兼容 API，走 rclone），
+**只保留最新一份**：固定对象名，每小时覆盖。S3 的对象替换是原子的——上传失败
+或中断时旧快照原样保留，不存在「没有备份」的窗口。直接拷贝 WAL 模式下的库文件
+可能拷到写了一半的状态，所以快照用 `VACUUM INTO`（SQLite 自己的锁保证一致性，
+顺带压实），先 `PRAGMA quick_check` 验证再 zstd 压缩上传。
+
+一次性安装（服务器已有 rclone/sqlite3/zstd）：
+
+```bash
+# 1. 凭证：Cloudflare 仪表盘 -> R2 -> Manage R2 API Tokens 建一个
+#    仅限该桶的 Object Read & Write token，填进 backup.env.example
+#    并放到 /opt/dhtsearch/.backup.env（chmod 600）
+# 2. 单元文件：
+cp scripts/systemd/dhtsearch-backup.{service,timer} /etc/systemd/system/
+systemctl daemon-reload && systemctl enable --now dhtsearch-backup.timer
+# 3. 手动跑一次验证：
+systemctl start dhtsearch-backup && journalctl -u dhtsearch-backup -n 5
+```
+
+恢复：下载对象、`zstd -d` 解压、停 `dhtsearch-api`、替换
+`data/dhtsearch.db`、重启即可（脚本头部有完整命令）。
+
 ## 本地爬虫 + 增量同步（可选）
 
 除了在服务器上爬，还可以在本地跑第二个爬虫实例，定时把增量索引合并到服务器：

--- a/backup.env.example
+++ b/backup.env.example
@@ -1,0 +1,19 @@
+# Copy to /opt/dhtsearch/.backup.env on the server and fill in. Used by
+# scripts/backup-r2.sh (hourly systemd timer). Keep it out of git and
+# root-only:  chmod 600 /opt/dhtsearch/.backup.env
+#
+# Create the credentials in the Cloudflare dashboard:
+#   R2 -> Manage R2 API Tokens -> Create API Token
+#   Permission: Object Read & Write, scoped to the one backup bucket.
+# The account id is in the dash URL or on the R2 overview page.
+
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET=dhtsearch-backup
+
+# Optional overrides (defaults shown). Only the latest snapshot is kept —
+# one object, overwritten every hour (S3 replacement is atomic, so a failed
+# upload never destroys the previous snapshot).
+# DB_PATH=/opt/dhtsearch/data/dhtsearch.db
+# BACKUP_OBJECT=dhtsearch-latest.db.zst

--- a/deploy.sh
+++ b/deploy.sh
@@ -47,6 +47,10 @@ echo "==> Uploading to $DEPLOY_HOST:$DEPLOY_DIR"
 ssh "$DEPLOY_HOST" "mkdir -p '$DEPLOY_DIR/data' '$DEPLOY_DIR/web'"
 rsync -az "$BUILD_DIR/dhtsearch-server" "$DEPLOY_HOST:$DEPLOY_DIR/server"
 rsync -az --delete "$BUILD_DIR/web/" "$DEPLOY_HOST:$DEPLOY_DIR/web/"
+# Backup script rides along so fixes propagate; its systemd units and
+# credentials are one-time server setup like the other units (see
+# scripts/systemd/ and backup.env.example).
+rsync -az "$ROOT_DIR/scripts/backup-r2.sh" "$DEPLOY_HOST:$DEPLOY_DIR/backup-r2.sh"
 
 echo "==> Restarting services"
 ssh "$DEPLOY_HOST" "systemctl restart dhtsearch-api dhtsearch-web"

--- a/scripts/backup-r2.sh
+++ b/scripts/backup-r2.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# backup-r2.sh — snapshot the SQLite database and upload it to Cloudflare R2,
+# keeping only the latest snapshot (one object, overwritten each run).
+#
+# Designed to run hourly on the server from a systemd timer (see
+# scripts/systemd/). A raw copy of a live WAL database can be torn mid-write,
+# so the snapshot is taken with VACUUM INTO — a consistent, compacted copy
+# made under SQLite's own locking — then verified, compressed and uploaded.
+# S3 object replacement is atomic: a failed or interrupted upload leaves the
+# previous snapshot untouched, so there is never a window without a backup.
+#
+# No credentials live in this file. Everything comes from an env file
+# (default /opt/dhtsearch/.backup.env, override with BACKUP_ENV_FILE):
+#
+#   R2_ACCOUNT_ID         (required) Cloudflare account id (hex, from the dash)
+#   R2_ACCESS_KEY_ID      (required) R2 S3 API token key id
+#   R2_SECRET_ACCESS_KEY  (required) R2 S3 API token secret
+#   R2_BUCKET             (required) bucket name, e.g. dhtsearch-backup
+#   DB_PATH               (optional) default /opt/dhtsearch/data/dhtsearch.db
+#   BACKUP_OBJECT         (optional) object key, default dhtsearch-latest.db.zst
+#
+# Restore:
+#   rclone copyto dhtr2:<bucket>/dhtsearch-latest.db.zst /tmp/x.db.zst
+#   zstd -d /tmp/x.db.zst && systemctl stop dhtsearch-api \
+#     && mv /tmp/x.db /opt/dhtsearch/data/dhtsearch.db \
+#     && systemctl start dhtsearch-api
+
+set -euo pipefail
+
+ENV_FILE="${BACKUP_ENV_FILE:-/opt/dhtsearch/.backup.env}"
+if [ ! -f "$ENV_FILE" ]; then
+    echo "backup: env file $ENV_FILE not found" >&2
+    exit 1
+fi
+# shellcheck source=/dev/null
+. "$ENV_FILE"
+
+: "${R2_ACCOUNT_ID:?R2_ACCOUNT_ID missing from $ENV_FILE}"
+: "${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID missing from $ENV_FILE}"
+: "${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY missing from $ENV_FILE}"
+: "${R2_BUCKET:?R2_BUCKET missing from $ENV_FILE}"
+DB_PATH="${DB_PATH:-/opt/dhtsearch/data/dhtsearch.db}"
+BACKUP_OBJECT="${BACKUP_OBJECT:-dhtsearch-latest.db.zst}"
+
+# rclone remote defined entirely via environment — no rclone.conf involvement,
+# so this cannot collide with other remotes on the machine.
+export RCLONE_CONFIG_DHTR2_TYPE=s3
+export RCLONE_CONFIG_DHTR2_PROVIDER=Cloudflare
+export RCLONE_CONFIG_DHTR2_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+export RCLONE_CONFIG_DHTR2_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+export RCLONE_CONFIG_DHTR2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+export RCLONE_CONFIG_DHTR2_ACL=private
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+SNAP="$WORK_DIR/dhtsearch.db"
+
+sqlite3 "$DB_PATH" "VACUUM INTO '$SNAP'"
+
+# A backup that doesn't restore is noise with a false sense of safety.
+CHECK="$(sqlite3 "$SNAP" "PRAGMA quick_check;")"
+if [ "$CHECK" != "ok" ]; then
+    echo "backup: snapshot failed quick_check: $CHECK" >&2
+    exit 1
+fi
+
+zstd -q -T0 "$SNAP" -o "$SNAP.zst"
+
+DEST="dhtr2:$R2_BUCKET/$BACKUP_OBJECT"
+rclone copyto --s3-no-check-bucket "$SNAP.zst" "$DEST"
+
+# Confirm the object is really there and fresh before declaring success.
+AGE="$(rclone lsf --format tp "$DEST" | head -1)"
+if [ -z "$AGE" ]; then
+    echo "backup: uploaded object not visible in listing" >&2
+    exit 1
+fi
+
+echo "backup: OK $DEST ($(du -h "$SNAP.zst" | cut -f1) compressed, remote: $AGE)"

--- a/scripts/systemd/dhtsearch-backup.service
+++ b/scripts/systemd/dhtsearch-backup.service
@@ -1,0 +1,20 @@
+# One-shot database backup to Cloudflare R2. Fired by dhtsearch-backup.timer;
+# run manually with: systemctl start dhtsearch-backup
+#
+# Install (one-time, matching deploy.sh's "units are server setup" rule):
+#   cp scripts/systemd/dhtsearch-backup.{service,timer} /etc/systemd/system/
+#   systemctl daemon-reload && systemctl enable --now dhtsearch-backup.timer
+[Unit]
+Description=DHTSearch hourly database backup to Cloudflare R2
+# Backups are worth taking even if the API is down; no Requires= on purpose.
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/dhtsearch/backup-r2.sh
+# The snapshot runs VACUUM INTO on a ~tens-of-MB database; give it slack but
+# never let a hung upload pile onto the next hour's run.
+TimeoutStartSec=15min
+Nice=10
+IOSchedulingClass=idle

--- a/scripts/systemd/dhtsearch-backup.timer
+++ b/scripts/systemd/dhtsearch-backup.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Hourly DHTSearch database backup to Cloudflare R2
+
+[Timer]
+OnCalendar=hourly
+# Spread the start over 5 minutes so the backup doesn't always collide with
+# the hourly LLM moderation pass, and catch up after reboots/downtime.
+RandomizedDelaySec=300
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## What

Hourly SQLite backup to Cloudflare R2, keeping **only the latest snapshot** (one fixed object, overwritten each run).

## How

- `scripts/backup-r2.sh`: `VACUUM INTO` snapshot (consistent under SQLite's locking — raw-copying a live WAL db can tear), `PRAGMA quick_check` verification, `zstd` compression, upload via rclone's S3 backend, post-upload listing check. S3 object replacement is atomic, so an interrupted upload never destroys the previous snapshot.
- `scripts/systemd/dhtsearch-backup.{service,timer}`: hourly oneshot, 5-min randomized delay (avoids always colliding with the hourly moderation pass), `Persistent=true` catch-up, 15-min timeout, idle IO priority.
- `backup.env.example`: template for the root-only `/opt/dhtsearch/.backup.env` (account id, S3 token, bucket). No credentials in repo or deploy pipeline.
- `deploy.sh` ships the script alongside the server binary; units remain one-time server setup, documented in the README (部署 section).

## Testing

- `bash -n` plus an end-to-end dry-run against a scratch SQLite db with a stubbed `rclone` (snapshot → quick_check → compress → upload → verify all exercised).
- Server already has `rclone`/`sqlite3`/`zstd` installed.
- Real-credential run pending an R2 API token (next step after merge).