### PR TITLE
Classify adult content instead of deleting it

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Co-authored by [Kimi K3](https://www.kimi.com/).
 
-一个自建索引的磁力链接搜索网站：Go 后端通过 DHT 网络爬虫实时采集磁力链接元数据，自动过滤成人内容与垃圾信息，Next.js 前端提供干净的搜索界面。
+一个自建索引的磁力链接搜索网站：Go 后端通过 DHT 网络爬虫实时采集磁力链接元数据，分类并默认隐藏成人内容，过滤垃圾信息，Next.js 前端提供可控的搜索界面。
 
 ## 架构
 
@@ -15,23 +15,26 @@ flowchart TB
     Scraper["Tracker scrape ranking<br/>BEP 15 batch scrape"]
     Fetcher["Metadata fetch<br/>BEP-9 workers"]
     Filter{"Filter engine<br/>keywords + heuristics + size"}
-    Discard["Drop and count<br/>adult / spam / too small"]
+    Adult["Mark category=adult"]
+    Discard["Drop and count<br/>spam / too small"]
     DB[("SQLite")]
     Web["Next.js frontend"]
     Mod["LLM moderation<br/>OpenRouter free model"]
-    Blocked[("blocked table")]
+    Categories[("categories table")]
 
     Crawler <-->|UDP| DHT
     Crawler -->|new infohashes| Scraper
     Scraper -->|ranked by seeders| Fetcher
     Fetcher --> Filter
-    Filter -->|hit| Discard
-    Filter -->|pass| DB
+	Filter -->|adult| Adult
+	Adult --> DB
+	Filter -->|spam / too small| Discard
+	Filter -->|general| DB
     Web <-->|REST API| DB
     DB -->|hourly incremental review| Mod
-    Mod -->|adult/spam: delete| Blocked
-    Mod -->|title ad-trim: clean_name| DB
-    Blocked -.->|rejected on insert, no resurrection| DB
+	Mod -->|category + confidence + reason| Categories
+	Mod -->|title ad-trim: clean_name| DB
+	Categories -.->|safe / all / adult views| Web
 ```
 
 - `server/` — Go 后端：DHT 爬虫（anacrolix/dht/v2）、BEP-9 元数据获取（anacrolix/torrent）、过滤引擎（中英文成人词表 + 垃圾启发式）、SQLite 存储（modernc.org/sqlite，无 cgo）、REST API（标准库 net/http）
@@ -121,7 +124,7 @@ LLM 审核相关（见下文「LLM 二次审核」）：
 | `MODERATION_INTERVAL` | `1h` | 审核周期 |
 | `MODERATION_BATCH_SIZE` | `100` | 每次请求送审的标题数 |
 | `MODERATION_MAX_BATCHES` | `20` | 每轮最多几批（0 = 不限），用于封顶开销 |
-| `MODERATION_DRY_RUN` | `false` | 只打日志不删除 |
+| `MODERATION_DRY_RUN` | `false` | 只打日志，不写入分类或审核时间 |
 | `MODERATION_TRIM_TITLES` | `true` | 顺带清理标题里的广告文字 |
 
 ### 前端
@@ -136,8 +139,10 @@ npm run dev                  # 开发
 
 ## API
 
-- `GET /api/search?q=xx&page=1&page_size=20` — 搜索（q 为空返回最新收录），结果含拼好的 magnet 链接
-- `GET /api/stats` — 收录数、成人/垃圾/体积过滤计数、LLM 审核统计、爬虫状态
+- `GET /api/search?q=xx&page=1&page_size=20` — 安全搜索（默认排除 adult/spam，q 为空返回最新收录）
+- `GET /api/search?q=xx&include_adult=true` — 搜索 general + adult，仍排除 spam
+- `GET /api/search?q=xx&category=adult` — 只搜索成人分类；也支持 `general` / `spam` / `all`
+- `GET /api/stats` — 收录数、分类数、垃圾/体积过滤计数、LLM 审核统计、爬虫状态
 - `GET /api/healthz` — 健康检查
 
 ## DoS 防护
@@ -184,31 +189,46 @@ API 搜索路径加入同一防护规则；仅监听回环地址时则不需要�
 
 ## 过滤策略
 
-### 第一道：入库前的静态过滤
+### 第一道：入库前的静态分类与过滤
 
-- **成人内容**：内置 230+ 中英文关键词（短词用词边界正则防误伤，如 Avatar/Avengers 不会被 "av" 误拦），对资源名和文件名匹配；JAV 番号等弱信号需叠加其他信号才判定
+- **成人内容**：内置 230+ 中英文关键词（短词用词边界正则防误伤，如 Avatar/Avengers 不会被 "av" 误拦），对资源名和文件名匹配；命中后以 `category='adult'` 入库，不再丢弃
 - **垃圾信息**：SEO 关键词堆叠、纯符号/超长名称、零大小或异常大小、超大文件数、随机字符串文件名占比等启发式规则
 - **体积下限**：总体积小于 `MIN_TORRENT_SIZE`（默认 100 MiB）的种子直接丢弃，滤掉假种、单图、纯链接/说明文件等垃圾
 
-命中任一即丢弃并计入统计（`adult_filtered` / `spam_filtered` / `size_filtered`）。规则见 `server/internal/filter/`。
+垃圾或体积下限命中仍会丢弃并计入 `spam_filtered` / `size_filtered`；成人命中计入 `adult_classified` 并保留。规则见 `server/internal/filter/`。
 
 ### 第二道：LLM 二次审核（每小时）
 
-静态词表只能拦住明写关键词的内容。后台每小时调用一次 OpenAI 兼容 API，对**尚未审核过**的库内记录做批量复审，判定为成人或垃圾的直接删除。
+静态词表只能识别明写关键词的内容。后台每小时调用一次 OpenAI 兼容 API，对**尚未审核过**的库内记录做批量复审。模型返回 `category`、`confidence` 和 `reason`，结果写入分类表，原始种子始终保留。
 
 - **增量**：每行有 `reviewed_at` 标记，只为没审过的行付费，不会每小时重扫全库
-- **不会复活**：删除的 infohash 写入 `blocked` 表，爬虫与增量同步都不会再把它加回来
-- **失败安全**：API 报错时该批不标记已审，下轮重试；模型返回无法解析、标签未知或漏项一律按 `ok` 处理，绝不因不确定而删除
+- **默认安全**：普通搜索排除 `adult` 和 `spam`；成人内容必须显式选择“全部”或“成人”视图
+- **可重新分类**：规则变化时重置 `reviewed_at` 即可重审，无需重新爬取已经收录的元数据
+- **失败安全**：API 报错时该批不标记已审，下轮重试；模型返回无法解析、标签未知或漏项一律按 `ok` 处理
 - **开销可控**：`MODERATION_MAX_BATCHES × MODERATION_BATCH_SIZE` 即每小时上限（默认 2000 条／小时）
 - **提示词**：明确要求「盗版本身不算垃圾」，否则模型会把整个库都判成垃圾；见 `server/internal/moderator/moderator.go` 的 `systemPromptFor`
 
-首次开启建议先跑一轮 dry-run 看日志，确认判定符合预期再放开删除：
+首次开启建议先跑一轮 dry-run 看日志，确认判定符合预期再写入分类：
 
 ```bash
 MODERATION_DRY_RUN=true go run ./cmd/server
 ```
 
-审核统计通过 `GET /api/stats` 的 `moderation` 字段暴露（`reviewed` / `adult_removed` / `spam_removed` / `errors` / `pending` / `blocked`）。
+审核统计通过 `GET /api/stats` 的 `moderation` 字段暴露（`reviewed` / `adult_classified` / `spam_classified` / `errors` / `pending` / `blocked`）。`blocked` 仅保留给版权等需要永久拒绝重新入库的场景。
+
+分类信息与主体记录分表，便于以后增加 anime、movie、music 等类型：
+
+```sql
+CREATE TABLE categories (
+    info_hash TEXT PRIMARY KEY,
+    category TEXT NOT NULL,
+    confidence REAL NOT NULL DEFAULT 1,
+    reason TEXT NOT NULL DEFAULT '',
+    reviewed_at INTEGER NOT NULL DEFAULT 0
+);
+```
+
+从旧版升级时，`blocked` 中历史 `adult` / `spam` 记录会一次性迁成分类占位并解除永久拒绝；由于旧版已经删除了主体元数据，只能等爬虫再次发现相同 infohash 后恢复，但恢复前后都不会泄漏到安全搜索。`copyright` 等永久移除原因不迁移。
 
 ### 顺带：标题去广告（`MODERATION_TRIM_TITLES`）
 

--- a/scripts/sync-to-remote.sh
+++ b/scripts/sync-to-remote.sh
@@ -33,12 +33,15 @@ DEPLOY_HOST="${DEPLOY_HOST:?DEPLOY_HOST is required (env or .deploy.env)}"
 DEPLOY_DIR="${DEPLOY_DIR:-/opt/dhtsearch}"
 LOCAL_DB="${LOCAL_DB:-$STATE_DIR/local.db}"
 WATERMARK_FILE="${WATERMARK_FILE:-$STATE_DIR/last_sync_ts}"
+CATEGORY_WATERMARK_FILE="${CATEGORY_WATERMARK_FILE:-${WATERMARK_FILE}.categories}"
 SQLITE=/usr/bin/sqlite3
 
 [ -f "$LOCAL_DB" ] || { echo "local db not found: $LOCAL_DB"; exit 1; }
 
 LAST=0
 [ -f "$WATERMARK_FILE" ] && LAST=$(cat "$WATERMARK_FILE")
+CATEGORY_LAST=0
+[ -f "$CATEGORY_WATERMARK_FILE" ] && CATEGORY_LAST=$(cat "$CATEGORY_WATERMARK_FILE")
 
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
@@ -49,23 +52,29 @@ DELTA="$TMP_DIR/delta.db"
 # during the export are picked up by the next run instead of being skipped.
 #
 # Columns are listed explicitly rather than SELECT *: the delta schema then
-# stays stable even when the two ends run different binaries, and reviewed_at
-# is deliberately left behind so the remote applies its own moderation policy
-# to synced rows.
+# stays stable even when the two ends run different binaries. Category rows are
+# copied separately so adult classifications cannot turn into general results
+# after a sync.
 "$SQLITE" "$LOCAL_DB" <<SQL
 PRAGMA busy_timeout=5000;
 ATTACH '$DELTA' AS d;
 CREATE TABLE d.torrents AS
   SELECT info_hash, name, total_size, file_count, files, created_at
   FROM torrents WHERE created_at > $LAST;
+CREATE TABLE d.categories AS
+  SELECT c.info_hash, c.category, c.confidence, c.reason, c.reviewed_at
+  FROM categories c JOIN torrents t ON t.info_hash = c.info_hash
+  WHERE t.created_at > $LAST OR c.reviewed_at > $CATEGORY_LAST;
 SQL
 
 COUNT=$("$SQLITE" "$DELTA" "SELECT COUNT(*) FROM torrents;")
-if [ "$COUNT" = "0" ]; then
+CATEGORY_COUNT=$("$SQLITE" "$DELTA" "SELECT COUNT(*) FROM categories;")
+if [ "$COUNT" = "0" ] && [ "$CATEGORY_COUNT" = "0" ]; then
     echo "nothing new to sync"
     exit 0
 fi
-NEW_MARK=$("$SQLITE" "$DELTA" "SELECT MAX(created_at) FROM torrents;")
+NEW_MARK=$("$SQLITE" "$DELTA" "SELECT COALESCE(MAX(created_at), $LAST) FROM torrents;")
+NEW_CATEGORY_MARK=$("$SQLITE" "$DELTA" "SELECT COALESCE(MAX(reviewed_at), $CATEGORY_LAST) FROM categories;")
 
 REMOTE_TMP=$(ssh "$DEPLOY_HOST" "mktemp /tmp/dhtsearch-sync.XXXXXX.db")
 scp -q "$DELTA" "$DEPLOY_HOST:$REMOTE_TMP"
@@ -77,7 +86,18 @@ ATTACH '$REMOTE_TMP' AS d;
 INSERT OR IGNORE INTO torrents (info_hash, name, total_size, file_count, files, created_at)
   SELECT info_hash, name, total_size, file_count, files, created_at FROM d.torrents
   WHERE info_hash NOT IN (SELECT info_hash FROM blocked);
+INSERT INTO categories (info_hash, category, confidence, reason, reviewed_at)
+  SELECT c.info_hash, c.category, c.confidence, c.reason, c.reviewed_at
+  FROM d.categories c JOIN torrents t ON t.info_hash = c.info_hash
+  WHERE 1
+  ON CONFLICT(info_hash) DO UPDATE SET
+    category = excluded.category,
+    confidence = excluded.confidence,
+    reason = excluded.reason,
+    reviewed_at = excluded.reviewed_at
+  WHERE excluded.reviewed_at >= categories.reviewed_at;
 \" && rm -f '$REMOTE_TMP'"
 
 echo "$NEW_MARK" > "$WATERMARK_FILE"
-echo "synced $COUNT torrents (watermark: $LAST -> $NEW_MARK)"
+echo "$NEW_CATEGORY_MARK" > "$CATEGORY_WATERMARK_FILE"
+echo "synced $COUNT torrents and $CATEGORY_COUNT categories (watermarks: $LAST -> $NEW_MARK, $CATEGORY_LAST -> $NEW_CATEGORY_MARK)"

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -222,10 +222,6 @@ func main() {
 		}
 		fetcher.Run(ctx, feed, func(rec metadata.Record) {
 			res := filter.Check(rec.Name, rec.Files, rec.TotalSize)
-			if res.Adult {
-				st.IncrStat("adult_filtered", 1)
-				return
-			}
 			if res.Spam {
 				st.IncrStat("spam_filtered", 1)
 				return
@@ -234,16 +230,25 @@ func main() {
 				st.IncrStat("size_filtered", 1)
 				return
 			}
-			if err := st.Upsert(store.Torrent{
+			torrent := store.Torrent{
 				InfoHash:  rec.InfoHash,
 				Name:      rec.Name,
 				TotalSize: rec.TotalSize,
 				FileCount: rec.FileCount,
 				Files:     rec.Files,
 				CreatedAt: time.Now().Unix(),
-			}); err != nil {
+			}
+			if res.Adult {
+				torrent.Category = store.CategoryAdult
+				torrent.CategoryConfidence = 1
+				torrent.CategoryReason = strings.Join(res.Reasons, "; ")
+			}
+			if err := st.Upsert(torrent); err != nil {
 				logger.Printf("store upsert: %v", err)
 				return
+			}
+			if res.Adult {
+				st.IncrStat("adult_classified", 1)
 			}
 			st.IncrStat("fetched", 1)
 		})

--- a/server/internal/api/api.go
+++ b/server/internal/api/api.go
@@ -94,12 +94,16 @@ type Server struct {
 	// Cached /api/stats body and empty-query total, both refreshed at most
 	// once per StatsTTL. The mutexes double as single-flight: one request
 	// pays for the refresh while the rest wait for its result.
-	statsMu   sync.Mutex
-	statsBody []byte
-	statsAt   time.Time
-	countMu   sync.Mutex
-	countVal  int
-	countAt   time.Time
+	statsMu    sync.Mutex
+	statsBody  []byte
+	statsAt    time.Time
+	countMu    sync.Mutex
+	countCache map[store.SearchFilter]cachedCount
+}
+
+type cachedCount struct {
+	value int
+	at    time.Time
 }
 
 // New builds the HTTP handler. crawlerStatus may be nil.
@@ -117,11 +121,12 @@ func New(st *store.Store, crawlerStatus func() CrawlerStatus, logger *log.Logger
 		opts.StatsTTL = defaultStatsTTL
 	}
 	s := &Server{
-		st:        st,
-		crawler:   crawlerStatus,
-		logger:    logger,
-		opts:      opts,
-		searchSem: make(chan struct{}, opts.MaxInflight),
+		st:         st,
+		crawler:    crawlerStatus,
+		logger:     logger,
+		opts:       opts,
+		searchSem:  make(chan struct{}, opts.MaxInflight),
+		countCache: make(map[store.SearchFilter]cachedCount),
 	}
 	if opts.RateRPS > 0 {
 		burst := opts.RateBurst
@@ -162,6 +167,8 @@ func (s *Server) Handler() http.Handler {
 type resultItem struct {
 	InfoHash  string `json:"info_hash"`
 	Name      string `json:"name"`
+	Category  string `json:"category"`
+	IsAdult   bool   `json:"is_adult"`
 	TotalSize int64  `json:"total_size"`
 	FileCount int    `json:"file_count"`
 	Files     any    `json:"files"`
@@ -184,6 +191,11 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	}
 	if (page-1)*pageSize > maxOffset {
 		page = maxOffset/pageSize + 1
+	}
+	filter, ok := parseSearchFilter(r)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid content filter")
+		return
 	}
 
 	// Admission gate: the store serializes queries on one connection, so
@@ -213,12 +225,12 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	if strings.TrimSpace(q) == "" {
 		// The landing page. Latest walks the created_at index instead of
 		// counting matches, and the total comes from the shared cache.
-		items, err = s.st.Latest(ctx, page, pageSize)
+		items, err = s.st.Latest(ctx, page, pageSize, filter)
 		if err == nil {
-			total, err = s.cachedCount(ctx)
+			total, err = s.cachedCount(ctx, filter)
 		}
 	} else {
-		items, total, err = s.st.Search(ctx, q, page, pageSize)
+		items, total, err = s.st.Search(ctx, q, page, pageSize, filter)
 	}
 	if err != nil {
 		if ctx.Err() != nil {
@@ -235,6 +247,8 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		results = append(results, resultItem{
 			InfoHash:  t.InfoHash,
 			Name:      t.Name,
+			Category:  t.Category,
+			IsAdult:   t.Category == store.CategoryAdult,
 			TotalSize: t.TotalSize,
 			FileCount: t.FileCount,
 			Files:     t.Files,
@@ -250,21 +264,42 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func parseSearchFilter(r *http.Request) (store.SearchFilter, bool) {
+	filter := store.SearchFilter{}
+	if raw := r.URL.Query().Get("include_adult"); raw != "" {
+		value, err := strconv.ParseBool(raw)
+		if err != nil {
+			return filter, false
+		}
+		filter.IncludeAdult = value
+	}
+	switch category := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("category"))); category {
+	case "":
+	case "all":
+		filter.IncludeAdult = true
+	case store.CategoryGeneral, store.CategoryAdult, store.CategorySpam:
+		filter.Category = category
+	default:
+		return filter, false
+	}
+	return filter, true
+}
+
 // cachedCount returns the total torrent count, at most StatsTTL stale.
 // COUNT(*) walks a full index, so the landing page must not pay for it per
 // request. The lock is held across the query on purpose: it makes concurrent
 // misses single-flight.
-func (s *Server) cachedCount(ctx context.Context) (int, error) {
+func (s *Server) cachedCount(ctx context.Context, filter store.SearchFilter) (int, error) {
 	s.countMu.Lock()
 	defer s.countMu.Unlock()
-	if !s.countAt.IsZero() && time.Since(s.countAt) < s.opts.StatsTTL {
-		return s.countVal, nil
+	if cached, ok := s.countCache[filter]; ok && time.Since(cached.at) < s.opts.StatsTTL {
+		return cached.value, nil
 	}
-	n, err := s.st.Count(ctx)
+	n, err := s.st.CountSearchable(ctx, filter)
 	if err != nil {
 		return 0, err
 	}
-	s.countVal, s.countAt = n, time.Now()
+	s.countCache[filter] = cachedCount{value: n, at: time.Now()}
 	return n, nil
 }
 
@@ -302,13 +337,19 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "stats failed")
 		return
 	}
+	categories, err := s.st.CategoryCounts(ctx)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "stats failed")
+		return
+	}
 	resp := map[string]any{
-		"torrents":       total,
-		"seen":           counters["seen"],
-		"fetched":        counters["fetched"],
-		"adult_filtered": counters["adult_filtered"],
-		"spam_filtered":  counters["spam_filtered"],
-		"size_filtered":  counters["size_filtered"],
+		"torrents":         total,
+		"seen":             counters["seen"],
+		"fetched":          counters["fetched"],
+		"adult_classified": categories[store.CategoryAdult],
+		"spam_filtered":    counters["spam_filtered"],
+		"size_filtered":    counters["size_filtered"],
+		"categories":       categories,
 		// Metadata fetch outcomes. A timeout share near 100% means the
 		// fetch pool, not discovery, is what caps indexing throughput.
 		"fetch": map[string]any{
@@ -317,12 +358,12 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 			"failed":    counters["meta_failed"],
 		},
 		"moderation": map[string]any{
-			"reviewed":      counters["llm_reviewed"],
-			"adult_removed": counters["llm_adult_removed"],
-			"spam_removed":  counters["llm_spam_removed"],
-			"errors":        counters["llm_errors"],
-			"pending":       pending,
-			"blocked":       blocked,
+			"reviewed":         counters["llm_reviewed"],
+			"adult_classified": counters["llm_adult_classified"],
+			"spam_classified":  counters["llm_spam_classified"],
+			"errors":           counters["llm_errors"],
+			"pending":          pending,
+			"blocked":          blocked,
 		},
 	}
 	if s.crawler != nil {

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -105,6 +105,59 @@ func TestSearchClampsDeepPagination(t *testing.T) {
 	}
 }
 
+func TestSearchContentFilters(t *testing.T) {
+	st, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	for _, torrent := range []store.Torrent{
+		{InfoHash: "safe", Name: "safe movie", TotalSize: 1, CreatedAt: 100},
+		{InfoHash: "adult", Name: "adult movie", Category: store.CategoryAdult, TotalSize: 1, CreatedAt: 200},
+	} {
+		if err := st.Upsert(torrent); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := st.Classify([]store.Classification{{
+		InfoHash: "safe", Category: store.CategorySpam, Confidence: 0.9, Reason: "test",
+	}}, 300); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Upsert(store.Torrent{InfoHash: "general", Name: "general movie", TotalSize: 1, CreatedAt: 300}); err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(New(st, nil, nil, Options{}).Handler())
+	t.Cleanup(srv.Close)
+
+	if got := getJSON(t, srv.URL+"/api/search?q=")["total"].(float64); got != 1 {
+		t.Fatalf("safe total=%v, want 1", got)
+	}
+	if got := getJSON(t, srv.URL+"/api/search?q=&include_adult=true")["total"].(float64); got != 2 {
+		t.Fatalf("include-adult total=%v, want 2", got)
+	}
+	adult := getJSON(t, srv.URL+"/api/search?q=&category=adult")
+	if got := adult["total"].(float64); got != 1 {
+		t.Fatalf("adult total=%v, want 1", got)
+	}
+	result := adult["results"].([]any)[0].(map[string]any)
+	if result["category"] != "adult" || result["is_adult"] != true {
+		t.Fatalf("adult result=%v", result)
+	}
+	if got := getJSON(t, srv.URL+"/api/search?q=&category=spam")["total"].(float64); got != 1 {
+		t.Fatalf("spam total=%v, want 1", got)
+	}
+
+	resp, err := http.Get(srv.URL + "/api/search?include_adult=perhaps")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("invalid filter status=%d, want 400", resp.StatusCode)
+	}
+}
+
 func TestStats(t *testing.T) {
 	m := getJSON(t, testServer(t).URL+"/api/stats")
 	if m["torrents"].(float64) != 3 {

--- a/server/internal/filter/filter.go
+++ b/server/internal/filter/filter.go
@@ -1,5 +1,6 @@
-// Package filter implements adult/spam content filtering for indexed
-// torrents. A torrent is dropped when either Adult or Spam is true.
+// Package filter detects adult, spam and undersized torrent metadata. Adult
+// signals are persisted as classifications; spam and undersized records are
+// dropped by the ingestion pipeline.
 package filter
 
 import (
@@ -23,8 +24,8 @@ type Result struct {
 	Reasons  []string `json:"reasons,omitempty"`
 }
 
-// Rejected reports whether any signal fired, i.e. the torrent must not be
-// indexed.
+// Rejected reports whether any signal fired. It is retained for corpus
+// evaluation; ingestion handles Adult as a classification rather than a drop.
 func (r Result) Rejected() bool { return r.Adult || r.Spam || r.TooSmall }
 
 // MinTotalSize is the smallest torrent worth indexing. Anything below it is
@@ -110,8 +111,8 @@ func isShortASCII(s string) bool {
 	return true
 }
 
-// Check inspects a torrent's name, file list and total size and returns
-// whether it should be dropped as adult or spam content.
+// Check inspects a torrent's name, file list and total size and returns all
+// detected signals.
 func Check(name string, files []File, totalSize int64) Result {
 	var r Result
 	add := func(format string, args ...interface{}) {

--- a/server/internal/moderator/moderator.go
+++ b/server/internal/moderator/moderator.go
@@ -1,10 +1,9 @@
 // Package moderator periodically re-checks indexed torrents with an
-// OpenAI-compatible chat model and removes adult and spam listings that the
-// static keyword filter let through.
+// OpenAI-compatible chat model and classifies adult and spam listings without
+// deleting them.
 //
 // The pass is incremental: every torrent carries a reviewed_at stamp, so each
-// run only pays for rows it has never classified. Removed infohashes go on a
-// blocklist so the crawler cannot re-add them.
+// run only pays for rows it has never classified.
 package moderator
 
 import (
@@ -38,7 +37,7 @@ type Config struct {
 	BatchSize  int           // titles per request
 	MaxBatches int           // batches per sweep; 0 = unlimited
 	Timeout    time.Duration // per-request timeout
-	DryRun     bool          // classify and log, but delete nothing
+	DryRun     bool          // classify and log, but persist nothing
 	TrimTitles bool          // also strip advertising from titles
 	Logger     *log.Logger
 	HTTPClient *http.Client // optional; for tests
@@ -53,11 +52,11 @@ type Moderator struct {
 
 // Summary reports what a single sweep did.
 type Summary struct {
-	Reviewed int
-	Adult    int
-	Spam     int
-	Deleted  int64
-	Trimmed  int64
+	Reviewed   int
+	Adult      int
+	Spam       int
+	Classified int64
+	Trimmed    int64
 }
 
 // New validates cfg and builds a Moderator.
@@ -111,8 +110,8 @@ func (m *Moderator) Run(ctx context.Context) {
 				continue
 			}
 			if s.Reviewed > 0 {
-				m.cfg.Logger.Printf("moderator: reviewed=%d adult=%d spam=%d deleted=%d trimmed=%d",
-					s.Reviewed, s.Adult, s.Spam, s.Deleted, s.Trimmed)
+				m.cfg.Logger.Printf("moderator: reviewed=%d adult=%d spam=%d classified=%d trimmed=%d",
+					s.Reviewed, s.Adult, s.Spam, s.Classified, s.Trimmed)
 			}
 		}
 	}
@@ -134,10 +133,13 @@ func (m *Moderator) SweepOnce(ctx context.Context) (Summary, error) {
 		total.Reviewed += s.Reviewed
 		total.Adult += s.Adult
 		total.Spam += s.Spam
-		total.Deleted += s.Deleted
+		total.Classified += s.Classified
 		total.Trimmed += s.Trimmed
 		if err != nil {
 			return total, err
+		}
+		if m.cfg.DryRun {
+			return total, nil
 		}
 	}
 	return total, nil
@@ -154,11 +156,15 @@ func (m *Moderator) reviewBatch(ctx context.Context, cands []store.Candidate) (S
 	now := time.Now().Unix()
 	var adultH, adultN, spamH, spamN []string
 	trims := map[string]string{}
+	classifications := make([]store.Classification, 0, len(cands))
 	for i, c := range cands {
+		category := store.CategoryGeneral
 		switch verdicts[i].label {
 		case labelAdult:
+			category = store.CategoryAdult
 			adultH, adultN = append(adultH, c.InfoHash), append(adultN, c.Name)
 		case labelSpam:
+			category = store.CategorySpam
 			spamH, spamN = append(spamH, c.InfoHash), append(spamN, c.Name)
 		default:
 			// Only worth trimming titles that survive moderation.
@@ -166,6 +172,10 @@ func (m *Moderator) reviewBatch(ctx context.Context, cands []store.Candidate) (S
 				trims[c.InfoHash] = v
 			}
 		}
+		classifications = append(classifications, store.Classification{
+			InfoHash: c.InfoHash, Category: category,
+			Confidence: verdicts[i].confidence, Reason: verdicts[i].reason,
+		})
 	}
 	s.Reviewed, s.Adult, s.Spam = len(cands), len(adultH), len(spamH)
 
@@ -181,47 +191,31 @@ func (m *Moderator) reviewBatch(ctx context.Context, cands []store.Candidate) (S
 
 	if m.cfg.DryRun {
 		for i, h := range adultH {
-			m.cfg.Logger.Printf("moderator: [dry-run] would remove adult %s %q", h, adultN[i])
+			m.cfg.Logger.Printf("moderator: [dry-run] would classify adult %s %q", h, adultN[i])
 		}
 		for i, h := range spamH {
-			m.cfg.Logger.Printf("moderator: [dry-run] would remove spam %s %q", h, spamN[i])
+			m.cfg.Logger.Printf("moderator: [dry-run] would classify spam %s %q", h, spamN[i])
 		}
-	} else {
-		n, err := m.st.SetCleanNames(trims)
-		if err != nil {
-			return s, fmt.Errorf("set clean names: %w", err)
-		}
-		s.Trimmed = n
-		m.st.IncrStat("llm_titles_trimmed", n)
-		for _, g := range []struct {
-			hashes, names []string
-			reason, stat  string
-		}{
-			{adultH, adultN, labelAdult, "llm_adult_removed"},
-			{spamH, spamN, labelSpam, "llm_spam_removed"},
-		} {
-			if len(g.hashes) == 0 {
-				continue
-			}
-			n, err := m.st.Block(g.hashes, g.names, g.reason, now)
-			if err != nil {
-				return s, fmt.Errorf("block %s: %w", g.reason, err)
-			}
-			s.Deleted += n
-			m.st.IncrStat(g.stat, n)
-			for i, h := range g.hashes {
-				m.cfg.Logger.Printf("moderator: removed %s %s %q", g.reason, h, g.names[i])
-			}
-		}
+		return s, nil
 	}
 
-	// Mark the whole batch reviewed. Rows just deleted simply match nothing.
-	hashes := make([]string, len(cands))
-	for i, c := range cands {
-		hashes[i] = c.InfoHash
+	n, err := m.st.SetCleanNames(trims)
+	if err != nil {
+		return s, fmt.Errorf("set clean names: %w", err)
 	}
-	if err := m.st.MarkReviewed(hashes, now); err != nil {
-		return s, fmt.Errorf("mark reviewed: %w", err)
+	s.Trimmed = n
+	m.st.IncrStat("llm_titles_trimmed", n)
+	if err := m.st.Classify(classifications, now); err != nil {
+		return s, fmt.Errorf("store classifications: %w", err)
+	}
+	s.Classified = int64(len(classifications))
+	m.st.IncrStat("llm_adult_classified", int64(len(adultH)))
+	m.st.IncrStat("llm_spam_classified", int64(len(spamH)))
+	for i, h := range adultH {
+		m.cfg.Logger.Printf("moderator: classified adult %s %q", h, adultN[i])
+	}
+	for i, h := range spamH {
+		m.cfg.Logger.Printf("moderator: classified spam %s %q", h, spamN[i])
 	}
 	m.st.IncrStat("llm_reviewed", int64(len(cands)))
 	return s, nil
@@ -231,10 +225,10 @@ func (m *Moderator) reviewBatch(ctx context.Context, cands []store.Candidate) (S
 // entirely when the feature is off, so it costs no tokens.
 func systemPromptFor(trim bool) string {
 	if trim {
-		return promptHead + "For each one, assign a label and return a cleaned-up title.\n" +
+		return promptHead + "For each one, assign a category and return a cleaned-up title.\n" +
 			promptLabel + promptClean + promptTailTrim
 	}
-	return promptHead + "Assign each one a label.\n" + promptLabel + promptTail
+	return promptHead + "Assign each one a category.\n" + promptLabel + promptTail
 }
 
 const promptHead = `You are a content-moderation classifier for a BitTorrent metadata index.
@@ -243,7 +237,7 @@ You receive a JSON array of torrent listings, each with "i" (its number),
 context. `
 
 const promptLabel = `
-LABEL — assign each listing exactly one:
+CATEGORY — assign each listing exactly one:
 
 - "adult": pornography or sexually explicit material (including JAV, hentai,
   camgirl/webcam rips, escort or sex-work advertising).
@@ -289,19 +283,21 @@ string, and never delete so much that the work is no longer identifiable.
 
 const promptTailTrim = `
 Respond with JSON only, no prose, in exactly this shape:
-{"verdicts":[{"i":1,"label":"ok","clean":"cleaned title"},{"i":2,"label":"adult","clean":"cleaned title"}]}
+{"verdicts":[{"i":1,"category":"ok","confidence":0.98,"reason":"brief reason","clean":"cleaned title"},{"i":2,"category":"adult","confidence":0.95,"reason":"brief reason","clean":"cleaned title"}]}
 Include exactly one entry for every input number.`
 
 const promptTail = `
 Respond with JSON only, no prose, in exactly this shape:
-{"verdicts":[{"i":1,"label":"ok"},{"i":2,"label":"adult"}]}
+{"verdicts":[{"i":1,"category":"ok","confidence":0.98,"reason":"brief reason"},{"i":2,"category":"adult","confidence":0.95,"reason":"brief reason"}]}
 Include exactly one entry for every input number.`
 
 // verdict is the model's answer for one candidate. clean is empty unless the
 // model proposed a trimmed title that passed validation.
 type verdict struct {
-	label string
-	clean string
+	label      string
+	clean      string
+	confidence float64
+	reason     string
 }
 
 // classify returns a verdict per candidate, aligned by index. Entries the model
@@ -350,12 +346,18 @@ func (m *Moderator) classify(ctx context.Context, cands []store.Candidate) ([]ve
 		if v.I < 1 || v.I > len(cands) {
 			continue
 		}
-		switch strings.ToLower(strings.TrimSpace(v.Label)) {
+		category := v.Category
+		if category == "" {
+			category = v.Label // tolerate the previous response shape
+		}
+		switch strings.ToLower(strings.TrimSpace(category)) {
 		case labelAdult:
 			out[v.I-1].label = labelAdult
 		case labelSpam:
 			out[v.I-1].label = labelSpam
 		}
+		out[v.I-1].confidence = v.Confidence
+		out[v.I-1].reason = strings.TrimSpace(v.Reason)
 		if m.cfg.TrimTitles {
 			out[v.I-1].clean = cleanTitle(cands[v.I-1].Name, v.Clean)
 		}
@@ -556,8 +558,11 @@ type promptItem struct {
 
 type verdictResponse struct {
 	Verdicts []struct {
-		I     int    `json:"i"`
-		Label string `json:"label"`
-		Clean string `json:"clean"`
+		I          int     `json:"i"`
+		Category   string  `json:"category"`
+		Label      string  `json:"label"`
+		Confidence float64 `json:"confidence"`
+		Reason     string  `json:"reason"`
+		Clean      string  `json:"clean"`
 	} `json:"verdicts"`
 }

--- a/server/internal/moderator/moderator_test.go
+++ b/server/internal/moderator/moderator_test.go
@@ -57,8 +57,10 @@ func fakeAPI(t *testing.T, label func(title string) string, calls *int32) *httpt
 			t.Fatal(err)
 		}
 		type v struct {
-			I     int    `json:"i"`
-			Label string `json:"label"`
+			I          int     `json:"i"`
+			Category   string  `json:"category"`
+			Confidence float64 `json:"confidence"`
+			Reason     string  `json:"reason"`
 		}
 		var items []promptItem
 		if err := json.Unmarshal([]byte(req.Messages[1].Content), &items); err != nil {
@@ -66,7 +68,7 @@ func fakeAPI(t *testing.T, label func(title string) string, calls *int32) *httpt
 		}
 		var out []v
 		for _, it := range items {
-			out = append(out, v{I: it.I, Label: label(it.Title)})
+			out = append(out, v{I: it.I, Category: label(it.Title), Confidence: 0.9, Reason: "test reason"})
 		}
 		content, _ := json.Marshal(map[string]any{"verdicts": out})
 		json.NewEncoder(w).Encode(chatResponse{Choices: []struct {
@@ -93,7 +95,7 @@ func newMod(t *testing.T, st *store.Store, url string, tweak func(*Config)) *Mod
 	return m
 }
 
-func TestSweepRemovesAdultAndSpamKeepsOK(t *testing.T) {
+func TestSweepClassifiesAdultAndSpamKeepsAllRows(t *testing.T) {
 	st := newStore(t)
 	seed(t, st, "Big Buck Bunny 1080p", "Hot XXX Collection", "FREE CRACK DOWNLOAD click here", "Ubuntu 24.04 ISO")
 
@@ -111,7 +113,7 @@ func TestSweepRemovesAdultAndSpamKeepsOK(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s.Reviewed != 4 || s.Adult != 1 || s.Spam != 1 || s.Deleted != 2 {
+	if s.Reviewed != 4 || s.Adult != 1 || s.Spam != 1 || s.Classified != 4 {
 		t.Fatalf("summary = %+v", s)
 	}
 
@@ -120,12 +122,21 @@ func TestSweepRemovesAdultAndSpamKeepsOK(t *testing.T) {
 		t.Fatal(err)
 	}
 	if total != 2 {
-		t.Fatalf("remaining = %d, want 2", total)
+		t.Fatalf("safe results = %d, want 2", total)
 	}
 	for _, it := range items {
 		if strings.Contains(it.Name, "XXX") || strings.Contains(it.Name, "CRACK") {
 			t.Fatalf("flagged torrent survived: %q", it.Name)
 		}
+	}
+	if _, total, err := st.Search(t.Context(), "", 1, 10, store.SearchFilter{Category: store.CategoryAdult}); err != nil || total != 1 {
+		t.Fatalf("adult results = %d, err=%v; want 1", total, err)
+	}
+	if _, total, err := st.Search(t.Context(), "", 1, 10, store.SearchFilter{Category: store.CategorySpam}); err != nil || total != 1 {
+		t.Fatalf("spam results = %d, err=%v; want 1", total, err)
+	}
+	if total, _ := st.Count(t.Context()); total != 4 {
+		t.Fatalf("stored rows = %d, want 4", total)
 	}
 }
 
@@ -151,7 +162,7 @@ func TestReviewedRowsAreNotReclassified(t *testing.T) {
 	}
 }
 
-func TestBlockedTorrentIsNotReAdded(t *testing.T) {
+func TestClassifiedTorrentIsRetainedAcrossRediscovery(t *testing.T) {
 	st := newStore(t)
 	seed(t, st, "Hot XXX Collection")
 	srv := fakeAPI(t, func(string) string { return "adult" }, nil)
@@ -166,10 +177,13 @@ func TestBlockedTorrentIsNotReAdded(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, total, _ := st.Search(t.Context(), "", 1, 10); total != 0 {
-		t.Fatalf("blocked infohash was re-added (total=%d)", total)
+		t.Fatalf("adult torrent leaked into safe results (total=%d)", total)
 	}
-	if n, _ := st.BlockedCount(t.Context()); n != 1 {
-		t.Fatalf("blocked count = %d, want 1", n)
+	if _, total, _ := st.Search(t.Context(), "", 1, 10, store.SearchFilter{Category: store.CategoryAdult}); total != 1 {
+		t.Fatalf("adult results = %d, want 1", total)
+	}
+	if n, _ := st.BlockedCount(t.Context()); n != 0 {
+		t.Fatalf("blocked count = %d, want 0", n)
 	}
 }
 
@@ -183,11 +197,14 @@ func TestDryRunDeletesNothing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s.Adult != 1 || s.Deleted != 0 {
-		t.Fatalf("summary = %+v, want Adult=1 Deleted=0", s)
+	if s.Adult != 1 || s.Classified != 0 {
+		t.Fatalf("summary = %+v, want Adult=1 Classified=0", s)
 	}
 	if _, total, _ := st.Search(t.Context(), "", 1, 10); total != 1 {
 		t.Fatalf("dry run deleted rows (total=%d)", total)
+	}
+	if n, _ := st.PendingReviewCount(t.Context()); n != 1 {
+		t.Fatalf("dry run marked row reviewed (pending=%d)", n)
 	}
 }
 
@@ -254,8 +271,8 @@ func TestUnknownAndMissingLabelsDefaultToOK(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s.Deleted != 0 {
-		t.Fatalf("deleted %d rows on malformed verdicts, want 0", s.Deleted)
+	if s.Classified != 3 {
+		t.Fatalf("classified %d rows, want 3", s.Classified)
 	}
 	if _, total, _ := st.Search(t.Context(), "", 1, 10); total != 3 {
 		t.Fatalf("total = %d, want 3", total)

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -18,12 +18,39 @@ import (
 
 // Torrent is one indexed torrent record.
 type Torrent struct {
-	InfoHash  string        `json:"info_hash"`
-	Name      string        `json:"name"`
-	TotalSize int64         `json:"total_size"`
-	FileCount int           `json:"file_count"`
-	Files     []filter.File `json:"files"`
-	CreatedAt int64         `json:"created_at"`
+	InfoHash string `json:"info_hash"`
+	Name     string `json:"name"`
+	Category string `json:"category"`
+	// Classification metadata is written on ingest but not exposed as part of
+	// the torrent payload; public results only need Category.
+	CategoryConfidence float64       `json:"-"`
+	CategoryReason     string        `json:"-"`
+	TotalSize          int64         `json:"total_size"`
+	FileCount          int           `json:"file_count"`
+	Files              []filter.File `json:"files"`
+	CreatedAt          int64         `json:"created_at"`
+}
+
+const (
+	CategoryGeneral = "general"
+	CategoryAdult   = "adult"
+	CategorySpam    = "spam"
+)
+
+// SearchFilter controls which classified rows are visible. The zero value is
+// safe for public search: adult and spam rows are excluded.
+type SearchFilter struct {
+	IncludeAdult bool
+	Category     string
+}
+
+// Classification is a persisted moderation decision. Categories live in a
+// separate table so the taxonomy can expand without widening torrent rows.
+type Classification struct {
+	InfoHash   string
+	Category   string
+	Confidence float64
+	Reason     string
 }
 
 // Candidate is the slim projection of a torrent handed to the moderation
@@ -71,13 +98,20 @@ CREATE TABLE IF NOT EXISTS stats (
 	key   TEXT PRIMARY KEY,
 	value INTEGER NOT NULL
 );
--- Infohashes removed by moderation. Kept so the crawler cannot re-add (and
--- re-pay to re-classify) a torrent that was already rejected.
+-- Permanent removals (for example copyright). Adult/spam decisions live in
+-- categories so those records remain available to explicit filtered views.
 CREATE TABLE IF NOT EXISTS blocked (
 	info_hash  TEXT PRIMARY KEY,
 	reason     TEXT NOT NULL,
 	name       TEXT NOT NULL,
 	created_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS categories (
+	info_hash   TEXT PRIMARY KEY,
+	category    TEXT NOT NULL,
+	confidence  REAL NOT NULL DEFAULT 1,
+	reason      TEXT NOT NULL DEFAULT '',
+	reviewed_at INTEGER NOT NULL DEFAULT 0
 );`
 	if _, err := db.Exec(schema); err != nil {
 		db.Close()
@@ -104,6 +138,10 @@ CREATE TABLE IF NOT EXISTS blocked (
 		db.Close()
 		return nil, fmt.Errorf("migrate files_json to files: %w", err)
 	}
+	if err := migrateLegacyModerationBlocks(db); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migrate legacy moderation blocks: %w", err)
+	}
 	// Partial index: only unreviewed rows are indexed, so it stays tiny and the
 	// moderation sweep never scans the full table. Created after the migration
 	// above so the column it filters on is guaranteed to exist.
@@ -120,7 +158,45 @@ CREATE TABLE IF NOT EXISTS blocked (
 		db.Close()
 		return nil, fmt.Errorf("create created_at index: %w", err)
 	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_categories_category
+		ON categories(category, info_hash)`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("create category index: %w", err)
+	}
 	return &Store{db: db}, nil
+}
+
+// migrateLegacyModerationBlocks converts adult/spam hashes created by the old
+// destructive moderation flow into category placeholders. The torrent rows
+// no longer exist, but removing these hashes from blocked lets the crawler
+// restore their metadata; the placeholder keeps them hidden in the meantime
+// and immediately classifies them when they are rediscovered.
+func migrateLegacyModerationBlocks(db *sql.DB) error {
+	var migrated int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM stats WHERE key = 'legacy_block_categories_v1'`).Scan(&migrated); err != nil {
+		return err
+	}
+	if migrated != 0 {
+		return nil
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec(`INSERT INTO categories (info_hash, category, confidence, reason, reviewed_at)
+		SELECT info_hash, reason, 1, 'migrated from legacy block: ' || name, created_at
+		FROM blocked WHERE reason IN ('adult', 'spam')
+		ON CONFLICT(info_hash) DO NOTHING`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DELETE FROM blocked WHERE reason IN ('adult', 'spam')`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`INSERT INTO stats(key, value) VALUES ('legacy_block_categories_v1', 1)`); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // Shared zstd coders. EncodeAll/DecodeAll on a nil-stream coder are safe for
@@ -238,19 +314,41 @@ func migrateFilesBlob(db *sql.DB) error {
 	return nil
 }
 
-// Upsert inserts a torrent, ignoring duplicates (same info hash) and
-// infohashes previously rejected by moderation.
+// Upsert inserts a torrent, ignoring duplicates (same info hash) and hashes
+// explicitly blocked for reasons such as copyright removal. Adult/spam
+// moderation uses categories and does not add hashes to blocked.
 func (s *Store) Upsert(t Torrent) error {
 	fj, err := json.Marshal(t.Files)
 	if err != nil {
 		return err
 	}
-	_, err = s.db.Exec(
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	_, err = tx.Exec(
 		`INSERT OR IGNORE INTO torrents (info_hash, name, total_size, file_count, files, created_at)
 		 SELECT ?, ?, ?, ?, ?, ?
 		 WHERE NOT EXISTS (SELECT 1 FROM blocked WHERE info_hash = ?)`,
 		t.InfoHash, t.Name, t.TotalSize, t.FileCount, compressFiles(fj), t.CreatedAt, t.InfoHash)
-	return err
+	if err != nil {
+		return err
+	}
+	if t.Category != "" && t.Category != CategoryGeneral {
+		confidence := t.CategoryConfidence
+		if confidence <= 0 || confidence > 1 {
+			confidence = 1
+		}
+		if _, err := tx.Exec(`INSERT INTO categories (info_hash, category, confidence, reason, reviewed_at)
+			SELECT ?, ?, ?, ?, 0 WHERE EXISTS (SELECT 1 FROM torrents WHERE info_hash = ?)
+			ON CONFLICT(info_hash) DO UPDATE SET category = excluded.category,
+				confidence = excluded.confidence, reason = excluded.reason`,
+			t.InfoHash, t.Category, confidence, t.CategoryReason, t.InfoHash); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 // maxKeywords bounds how many query keywords turn into LIKE conditions.
@@ -262,25 +360,43 @@ const maxKeywords = 8
 
 // selectCols is the projection shared by Search and Latest, decoded by
 // scanTorrents.
-const selectCols = `SELECT info_hash, IIF(clean_name <> '', clean_name, name),
-	total_size, file_count, files, created_at FROM torrents`
+const selectCols = `SELECT t.info_hash, IIF(t.clean_name <> '', t.clean_name, t.name),
+	COALESCE(c.category, 'general'), t.total_size, t.file_count, t.files, t.created_at
+	FROM torrents t LEFT JOIN categories c ON c.info_hash = t.info_hash`
+
+func searchFilterSQL(filter SearchFilter) (string, []interface{}) {
+	if filter.Category != "" {
+		return `COALESCE(c.category, 'general') = ?`, []interface{}{filter.Category}
+	}
+	if filter.IncludeAdult {
+		return `COALESCE(c.category, 'general') <> 'spam'`, nil
+	}
+	return `COALESCE(c.category, 'general') NOT IN ('adult', 'spam')`, nil
+}
+
+func firstSearchFilter(filters []SearchFilter) SearchFilter {
+	if len(filters) == 0 {
+		return SearchFilter{}
+	}
+	return filters[0]
+}
 
 // Search finds torrents whose name contains every space-separated keyword
 // of query (AND semantics), newest first. An empty query returns the latest
 // additions. page is 1-based; pageSize must be > 0. ctx bounds the queries:
 // keyword matching is a full-table scan, so callers must be able to cut it
 // off when the client hangs up or a deadline passes.
-func (s *Store) Search(ctx context.Context, query string, page, pageSize int) (items []Torrent, total int, err error) {
+func (s *Store) Search(ctx context.Context, query string, page, pageSize int, filters ...SearchFilter) (items []Torrent, total int, err error) {
 	if page < 1 {
 		page = 1
 	}
-	where, args := "", []interface{}{}
+	filterWhere, args := searchFilterSQL(firstSearchFilter(filters))
+	conds := []string{filterWhere}
 	keywords := strings.Fields(query)
 	if len(keywords) > maxKeywords {
 		keywords = keywords[:maxKeywords]
 	}
 	if len(keywords) > 0 {
-		var conds []string
 		for _, kw := range keywords {
 			// Match either title: the raw one so trimming can never hide a
 			// result, and the cleaned one so a phrase that only reads
@@ -288,9 +404,10 @@ func (s *Store) Search(ctx context.Context, query string, page, pageSize int) (i
 			conds = append(conds, "(name LIKE ? ESCAPE '\\' OR clean_name LIKE ? ESCAPE '\\')")
 			args = append(args, "%"+escapeLike(kw)+"%", "%"+escapeLike(kw)+"%")
 		}
-		where = " WHERE " + strings.Join(conds, " AND ")
 	}
-	if err = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM torrents`+where, args...).Scan(&total); err != nil {
+	where := " WHERE " + strings.Join(conds, " AND ")
+	if err = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM torrents t
+		LEFT JOIN categories c ON c.info_hash = t.info_hash`+where, args...).Scan(&total); err != nil {
 		return nil, 0, err
 	}
 	q := selectCols + where + ` ORDER BY created_at DESC LIMIT ? OFFSET ?`
@@ -305,12 +422,14 @@ func (s *Store) Search(ctx context.Context, query string, page, pageSize int) (i
 // Latest returns a page of the newest torrents without counting the table.
 // It walks the created_at index, so its cost is O(pageSize + offset) — the
 // cheap path the landing page should take instead of Search("").
-func (s *Store) Latest(ctx context.Context, page, pageSize int) ([]Torrent, error) {
+func (s *Store) Latest(ctx context.Context, page, pageSize int, filters ...SearchFilter) ([]Torrent, error) {
 	if page < 1 {
 		page = 1
 	}
+	where, args := searchFilterSQL(firstSearchFilter(filters))
+	args = append(args, pageSize, (page-1)*pageSize)
 	rows, err := s.db.QueryContext(ctx,
-		selectCols+` ORDER BY created_at DESC LIMIT ? OFFSET ?`, pageSize, (page-1)*pageSize)
+		selectCols+` WHERE `+where+` ORDER BY t.created_at DESC LIMIT ? OFFSET ?`, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +443,7 @@ func scanTorrents(rows *sql.Rows) (items []Torrent, err error) {
 	for rows.Next() {
 		var t Torrent
 		var fb []byte
-		if err := rows.Scan(&t.InfoHash, &t.Name, &t.TotalSize, &t.FileCount, &fb, &t.CreatedAt); err != nil {
+		if err := rows.Scan(&t.InfoHash, &t.Name, &t.Category, &t.TotalSize, &t.FileCount, &fb, &t.CreatedAt); err != nil {
 			return nil, err
 		}
 		fj, err := decompressFiles(fb)
@@ -378,6 +497,49 @@ func (s *Store) MarkReviewed(hashes []string, ts int64) error {
 	return err
 }
 
+// Classify stores moderation decisions and marks the matching torrents as
+// reviewed in one transaction. No torrent row is deleted.
+func (s *Store) Classify(items []Classification, ts int64) error {
+	if len(items) == 0 {
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	up, err := tx.Prepare(`INSERT INTO categories
+		(info_hash, category, confidence, reason, reviewed_at)
+		SELECT ?, ?, ?, ?, ? WHERE EXISTS (SELECT 1 FROM torrents WHERE info_hash = ?)
+		ON CONFLICT(info_hash) DO UPDATE SET category = excluded.category,
+			confidence = excluded.confidence, reason = excluded.reason,
+			reviewed_at = excluded.reviewed_at`)
+	if err != nil {
+		return err
+	}
+	defer up.Close()
+	mark, err := tx.Prepare(`UPDATE torrents SET reviewed_at = ? WHERE info_hash = ?`)
+	if err != nil {
+		return err
+	}
+	defer mark.Close()
+	for _, item := range items {
+		confidence := item.Confidence
+		if confidence < 0 {
+			confidence = 0
+		} else if confidence > 1 {
+			confidence = 1
+		}
+		if _, err := up.Exec(item.InfoHash, item.Category, confidence, item.Reason, ts, item.InfoHash); err != nil {
+			return err
+		}
+		if _, err := mark.Exec(ts, item.InfoHash); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
 // SetCleanNames records trimmed titles. clean is keyed by info hash and holds
 // the title with promotional text removed; the raw name column is left alone.
 // Returns the number of rows updated.
@@ -412,9 +574,10 @@ func (s *Store) SetCleanNames(clean map[string]string) (int64, error) {
 	return n, tx.Commit()
 }
 
-// Block deletes the named torrents and records them as rejected so the
-// crawler cannot re-add them. names must be parallel to hashes; it is stored
-// only for the audit trail. Returns the number of rows actually deleted.
+// Block permanently removes named torrents and records them so the crawler
+// cannot re-add them. This is reserved for hard removals such as copyright;
+// adult/spam moderation uses Classify instead. names must be parallel to
+// hashes and is stored only for the audit trail.
 func (s *Store) Block(hashes, names []string, reason string, ts int64) (int64, error) {
 	if len(hashes) == 0 {
 		return 0, nil
@@ -455,7 +618,7 @@ func (s *Store) Block(hashes, names []string, reason string, ts int64) (int64, e
 	return n, tx.Commit()
 }
 
-// BlockedCount returns the number of moderation-rejected infohashes.
+// BlockedCount returns the number of permanently rejected infohashes.
 func (s *Store) BlockedCount(ctx context.Context) (int, error) {
 	var n int
 	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM blocked`).Scan(&n)
@@ -506,6 +669,35 @@ func (s *Store) Count(ctx context.Context) (int, error) {
 	var n int
 	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM torrents`).Scan(&n)
 	return n, err
+}
+
+// CountSearchable returns the total visible under filter.
+func (s *Store) CountSearchable(ctx context.Context, filter SearchFilter) (int, error) {
+	where, args := searchFilterSQL(filter)
+	var n int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM torrents t
+		LEFT JOIN categories c ON c.info_hash = t.info_hash WHERE `+where, args...).Scan(&n)
+	return n, err
+}
+
+// CategoryCounts returns the number of persisted rows per effective category.
+func (s *Store) CategoryCounts(ctx context.Context) (map[string]int64, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT COALESCE(c.category, 'general'), COUNT(*)
+		FROM torrents t LEFT JOIN categories c ON c.info_hash = t.info_hash GROUP BY 1`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]int64)
+	for rows.Next() {
+		var category string
+		var count int64
+		if err := rows.Scan(&category, &count); err != nil {
+			return nil, err
+		}
+		out[category] = count
+	}
+	return out, rows.Err()
 }
 
 // Close closes the database.

--- a/server/internal/store/store_test.go
+++ b/server/internal/store/store_test.go
@@ -328,3 +328,117 @@ func TestSetCleanNamesEmptyMapIsNoOp(t *testing.T) {
 		t.Fatalf("SetCleanNames(nil) = %d, %v; want 0, nil", n, err)
 	}
 }
+
+func TestAdultCategoryIsStoredAndFiltered(t *testing.T) {
+	s := openTest(t)
+	if err := s.Upsert(Torrent{
+		InfoHash: "adult", Name: "classified title", Category: CategoryAdult,
+		CategoryConfidence: 1, CategoryReason: "static keyword", TotalSize: 1 << 30, CreatedAt: 200,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Upsert(Torrent{InfoHash: "safe", Name: "safe title", TotalSize: 1 << 30, CreatedAt: 100}); err != nil {
+		t.Fatal(err)
+	}
+
+	items, total, err := s.Search(t.Context(), "", 1, 10)
+	if err != nil || total != 1 || items[0].InfoHash != "safe" {
+		t.Fatalf("safe search: items=%v total=%d err=%v", items, total, err)
+	}
+	items, total, err = s.Search(t.Context(), "classified", 1, 10, SearchFilter{IncludeAdult: true})
+	if err != nil || total != 1 || items[0].Category != CategoryAdult {
+		t.Fatalf("include adult: items=%v total=%d err=%v", items, total, err)
+	}
+	items, err = s.Latest(t.Context(), 1, 10, SearchFilter{Category: CategoryAdult})
+	if err != nil || len(items) != 1 || items[0].InfoHash != "adult" {
+		t.Fatalf("adult only: items=%v err=%v", items, err)
+	}
+	if count, err := s.CountSearchable(t.Context(), SearchFilter{IncludeAdult: true}); err != nil || count != 2 {
+		t.Fatalf("all searchable count=%d err=%v", count, err)
+	}
+
+	var confidence float64
+	var reason string
+	if err := s.db.QueryRow(`SELECT confidence, reason FROM categories WHERE info_hash='adult'`).Scan(&confidence, &reason); err != nil {
+		t.Fatal(err)
+	}
+	if confidence != 1 || reason != "static keyword" {
+		t.Fatalf("classification metadata = %v, %q", confidence, reason)
+	}
+}
+
+func TestClassifyUpdatesCategoryWithoutDeleting(t *testing.T) {
+	s := openTest(t)
+	if err := s.Upsert(Torrent{InfoHash: "aa", Name: "review me", TotalSize: 1 << 30, CreatedAt: 100}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Classify([]Classification{{
+		InfoHash: "aa", Category: CategoryAdult, Confidence: 0.91, Reason: "model reason",
+	}}, 500); err != nil {
+		t.Fatal(err)
+	}
+	if count, _ := s.Count(t.Context()); count != 1 {
+		t.Fatalf("stored count=%d, want 1", count)
+	}
+	if pending, _ := s.PendingReviewCount(t.Context()); pending != 0 {
+		t.Fatalf("pending=%d, want 0", pending)
+	}
+	var confidence float64
+	var reason string
+	if err := s.db.QueryRow(`SELECT confidence, reason FROM categories WHERE info_hash='aa'`).Scan(&confidence, &reason); err != nil {
+		t.Fatal(err)
+	}
+	if confidence != 0.91 || reason != "model reason" {
+		t.Fatalf("classification metadata=%v, %q", confidence, reason)
+	}
+	items, total, err := s.Search(t.Context(), "review", 1, 10, SearchFilter{Category: CategoryAdult})
+	if err != nil || total != 1 || items[0].InfoHash != "aa" {
+		t.Fatalf("classified search: items=%v total=%d err=%v", items, total, err)
+	}
+}
+
+func TestOpenMigratesLegacyAdultAndSpamBlocks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy-blocks.db")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`DELETE FROM stats WHERE key='legacy_block_categories_v1';
+		INSERT INTO blocked VALUES ('adult-old', 'adult', 'old adult title', 100);
+		INSERT INTO blocked VALUES ('spam-old', 'spam', 'old spam title', 101);
+		INSERT INTO blocked VALUES ('copyright-old', 'copyright', 'removed work', 102);`); err != nil {
+		s.Close()
+		t.Fatal(err)
+	}
+	s.Close()
+
+	s, err = Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if blocked, err := s.BlockedCount(t.Context()); err != nil || blocked != 1 {
+		t.Fatalf("permanent blocked=%d err=%v, want 1", blocked, err)
+	}
+	for _, torrent := range []Torrent{
+		{InfoHash: "adult-old", Name: "restored adult", TotalSize: 1, CreatedAt: 200},
+		{InfoHash: "spam-old", Name: "restored spam", TotalSize: 1, CreatedAt: 201},
+		{InfoHash: "copyright-old", Name: "must stay blocked", TotalSize: 1, CreatedAt: 202},
+	} {
+		if err := s.Upsert(torrent); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if count, _ := s.Count(t.Context()); count != 2 {
+		t.Fatalf("restored count=%d, want 2", count)
+	}
+	if _, total, _ := s.Search(t.Context(), "", 1, 10); total != 0 {
+		t.Fatalf("legacy classifications leaked into safe results: %d", total)
+	}
+	if _, total, _ := s.Search(t.Context(), "", 1, 10, SearchFilter{Category: CategoryAdult}); total != 1 {
+		t.Fatalf("adult category total=%d, want 1", total)
+	}
+	if _, total, _ := s.Search(t.Context(), "", 1, 10, SearchFilter{Category: CategorySpam}); total != 1 {
+		t.Fatalf("spam category total=%d, want 1", total)
+	}
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -15,7 +15,7 @@ export default async function Home() {
           干净、无广告的磁力链接搜索引擎
           <br className="sm:hidden" />
           <span className="hidden sm:inline"> · </span>
-          基于 DHT 网络实时收录，自动过滤成人内容与垃圾信息
+		  基于 DHT 网络实时收录，成人内容默认隐藏、可按需查看
         </p>
 
         <div className="mt-10">
@@ -30,8 +30,8 @@ export default async function Home() {
       <footer className="mt-16 text-center text-xs text-zinc-500">
         {stats ? (
           <p>
-            已收录 {formatCount(stats.torrents)} 条 · 已过滤成人内容{" "}
-            {formatCount(stats.adult_filtered)} 条 · 垃圾信息{" "}
+			已收录 {formatCount(stats.torrents)} 条 · 已分类成人内容{" "}
+			{formatCount(stats.adult_classified)} 条 · 已过滤垃圾信息{" "}
             {formatCount(stats.spam_filtered)} 条
             {stats.crawler_running === false && (
               <span className="ml-2 text-amber-500">（爬虫暂停中）</span>

--- a/web/app/search/page.tsx
+++ b/web/app/search/page.tsx
@@ -1,13 +1,13 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { fetchSearch, type SearchResponse } from "@/lib/api";
+import { fetchSearch, type ContentFilter, type SearchResponse } from "@/lib/api";
 import { formatCount } from "@/lib/format";
 import SearchBox from "@/components/SearchBox";
 import ResultList from "@/components/ResultList";
 import Pagination from "@/components/Pagination";
 
 interface PageProps {
-  searchParams: Promise<{ q?: string; page?: string }>;
+  searchParams: Promise<{ q?: string; page?: string; include_adult?: string; category?: string }>;
 }
 
 export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
@@ -26,11 +26,17 @@ export default async function SearchPage({ searchParams }: PageProps) {
   const q = (params.q ?? "").trim();
   const page = Math.max(1, parseInt(params.page ?? "1", 10) || 1);
   const pageSize = 20;
+  const contentFilter: ContentFilter =
+    params.category === "adult"
+      ? "adult"
+      : params.include_adult === "true"
+        ? "all"
+        : "safe";
 
   let data: SearchResponse | null = null;
   let error: string | null = null;
   try {
-    data = await fetchSearch(q, page, pageSize);
+    data = await fetchSearch(q, page, pageSize, contentFilter);
   } catch (e) {
     error = e instanceof Error ? e.message : "unknown error";
   }
@@ -46,16 +52,26 @@ export default async function SearchPage({ searchParams }: PageProps) {
           DHT<span className="text-emerald-500">Search</span>
         </Link>
         <div className="flex-1">
-          <SearchBox initialQuery={q} />
+          <SearchBox initialQuery={q} contentFilter={contentFilter} />
         </div>
       </header>
 
-      <div className="mt-4 rounded-md border border-emerald-900/50 bg-emerald-950/30 px-3 py-2 text-xs text-emerald-300/80">
-        🛡️ 本站结果已自动过滤成人内容与垃圾信息，请放心使用。
+      <ContentFilterTabs q={q} selected={contentFilter} />
+
+      <div className={`mt-3 rounded-md border px-3 py-2 text-xs ${
+        contentFilter === "safe"
+          ? "border-emerald-900/50 bg-emerald-950/30 text-emerald-300/80"
+          : "border-amber-900/50 bg-amber-950/30 text-amber-200/80"
+      }`}>
+        {contentFilter === "safe"
+          ? "🛡️ 安全模式已隐藏成人内容与垃圾信息。"
+          : contentFilter === "adult"
+            ? "🔞 当前仅显示标记为成人内容的结果。"
+            : "🔞 当前结果包含成人内容；垃圾信息仍然隐藏。"}
       </div>
 
       {error ? (
-        <BackendError q={q} detail={error} />
+        <BackendError q={q} contentFilter={contentFilter} detail={error} />
       ) : data && data.results && data.results.length > 0 ? (
         <>
           <p className="mt-4 text-sm text-zinc-400">
@@ -69,7 +85,7 @@ export default async function SearchPage({ searchParams }: PageProps) {
             )}
           </p>
           <ResultList results={data.results} />
-          <Pagination q={q} page={data.page ?? page} total={data.total ?? 0} pageSize={data.page_size ?? pageSize} />
+          <Pagination q={q} page={data.page ?? page} total={data.total ?? 0} pageSize={data.page_size ?? pageSize} contentFilter={contentFilter} />
         </>
       ) : (
         <div className="mt-16 text-center">
@@ -89,7 +105,49 @@ export default async function SearchPage({ searchParams }: PageProps) {
   );
 }
 
-function BackendError({ q, detail }: { q: string; detail: string }) {
+function ContentFilterTabs({ q, selected }: { q: string; selected: ContentFilter }) {
+  const filters: Array<{ value: ContentFilter; label: string }> = [
+    { value: "safe", label: "安全" },
+    { value: "all", label: "全部" },
+    { value: "adult", label: "成人" },
+  ];
+  const hrefFor = (value: ContentFilter) => {
+    const params = new URLSearchParams();
+    if (q) params.set("q", q);
+    if (value === "all") params.set("include_adult", "true");
+    if (value === "adult") params.set("category", "adult");
+    const suffix = params.toString();
+    return suffix ? `/search?${suffix}` : "/search";
+  };
+
+  return (
+    <nav aria-label="内容筛选" className="mt-4 flex gap-1 rounded-lg bg-zinc-900 p-1">
+      {filters.map((filter) => {
+        const href = hrefFor(filter.value);
+        return (
+		  <a
+			key={filter.value}
+			href={href}
+            className={`flex-1 rounded-md px-3 py-1.5 text-center text-sm transition-colors ${
+              selected === filter.value
+                ? "bg-zinc-700 text-zinc-100"
+                : "text-zinc-400 hover:text-zinc-200"
+            }`}
+          >
+            {filter.label}
+		  </a>
+        );
+      })}
+    </nav>
+  );
+}
+
+function BackendError({ q, contentFilter, detail }: { q: string; contentFilter: ContentFilter; detail: string }) {
+  const retryParams = new URLSearchParams();
+  if (q) retryParams.set("q", q);
+  if (contentFilter === "all") retryParams.set("include_adult", "true");
+  if (contentFilter === "adult") retryParams.set("category", "adult");
+  const retryQuery = retryParams.toString();
   return (
     <div className="mt-16 text-center">
       <p className="text-lg text-zinc-300">无法连接到搜索服务</p>
@@ -100,7 +158,7 @@ function BackendError({ q, detail }: { q: string; detail: string }) {
       </p>
       <p className="mt-1 font-mono text-xs text-zinc-600">{detail}</p>
       <Link
-        href={q ? `/search?q=${encodeURIComponent(q)}` : "/search"}
+        href={retryQuery ? `/search?${retryQuery}` : "/search"}
         className="mt-6 inline-block rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 text-sm text-zinc-300 hover:border-emerald-600 hover:text-emerald-400"
       >
         重试

--- a/web/components/Pagination.tsx
+++ b/web/components/Pagination.tsx
@@ -2,18 +2,24 @@
 
 import Link from "next/link";
 import type { MouseEvent } from "react";
+import type { ContentFilter } from "@/lib/api";
 
 interface PaginationProps {
   q: string;
   page: number;
   total: number;
   pageSize: number;
+  contentFilter?: ContentFilter;
 }
 
-export default function Pagination({ q, page, total, pageSize }: PaginationProps) {
+export default function Pagination({ q, page, total, pageSize, contentFilter = "safe" }: PaginationProps) {
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
-  const mkHref = (p: number) =>
-    `/search?q=${encodeURIComponent(q)}&page=${p}`;
+  const mkHref = (p: number) => {
+    const params = new URLSearchParams({ q, page: String(p) });
+    if (contentFilter === "all") params.set("include_adult", "true");
+    if (contentFilter === "adult") params.set("category", "adult");
+    return `/search?${params.toString()}`;
+  };
 
   const btnCls =
     "rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 text-sm text-zinc-300 transition-colors hover:border-emerald-600 hover:text-emerald-400";

--- a/web/components/ResultCard.tsx
+++ b/web/components/ResultCard.tsx
@@ -73,6 +73,9 @@ export default function ResultCard({
             {result.name || "(未命名)"}
           </h3>
           <p className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-zinc-400">
+			{result.is_adult && (
+			  <span className="rounded bg-rose-950/70 px-1.5 text-rose-300">成人内容</span>
+			)}
             <span>{formatSize(result.total_size)}</span>
             <span>{formatCount(totalFiles)} 个文件</span>
             <span>收录于 {formatRelativeTime(result.created_at)}</span>

--- a/web/components/SearchBox.tsx
+++ b/web/components/SearchBox.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { FormEvent, useState } from "react";
+import type { ContentFilter } from "@/lib/api";
 
 interface SearchBoxProps {
   initialQuery?: string;
   large?: boolean;
+  contentFilter?: ContentFilter;
 }
 
-export default function SearchBox({ initialQuery = "", large = false }: SearchBoxProps) {
+export default function SearchBox({ initialQuery = "", large = false, contentFilter = "safe" }: SearchBoxProps) {
   const [q, setQ] = useState(initialQuery);
 
   function onSubmit(e: FormEvent) {
@@ -17,9 +19,12 @@ export default function SearchBox({ initialQuery = "", large = false }: SearchBo
     // A client-side router fetch cannot display that HTML challenge, so make
     // search a document navigation and let Cloudflare complete its normal
     // challenge -> cf_clearance -> page flow.
-    window.location.assign(
-      query ? `/search?q=${encodeURIComponent(query)}` : "/search",
-    );
+    const params = new URLSearchParams();
+    if (query) params.set("q", query);
+    if (contentFilter === "all") params.set("include_adult", "true");
+    if (contentFilter === "adult") params.set("category", "adult");
+    const suffix = params.toString();
+    window.location.assign(suffix ? `/search?${suffix}` : "/search");
   }
 
   return (

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -33,12 +33,16 @@ export interface TorrentFile {
 export interface SearchResult {
   info_hash: string;
   name: string;
+  category: string;
+  is_adult: boolean;
   total_size: number;
   file_count: number;
   files?: TorrentFile[];
   magnet: string;
   created_at: number;
 }
+
+export type ContentFilter = "safe" | "all" | "adult";
 
 export interface SearchResponse {
   total: number;
@@ -51,21 +55,24 @@ export interface StatsResponse {
   torrents?: number;
   seen?: number;
   fetched?: number;
-  adult_filtered?: number;
+  adult_classified?: number;
   spam_filtered?: number;
   crawler_running?: boolean;
 }
 
 export async function fetchSearch(
-  q: string,
-  page: number,
-  pageSize = 20
+	q: string,
+	page: number,
+	pageSize = 20,
+	contentFilter: ContentFilter = "safe",
 ): Promise<SearchResponse> {
   const params = new URLSearchParams({
     q,
     page: String(page),
     page_size: String(pageSize),
   });
+  if (contentFilter === "all") params.set("include_adult", "true");
+  if (contentFilter === "adult") params.set("category", "adult");
   const res = await fetch(`${API_BASE}/api/search?${params.toString()}`, {
     cache: "no-store",
     headers: await clientIPHeaders(),


### PR DESCRIPTION
## Summary
- persist extensible category/confidence/reason/review metadata without deleting torrents
- mark static adult matches at ingest and classify LLM results as general/adult/spam
- keep default search safe; add include_adult and category filters plus Safe/All/Adult UI tabs
- sync category changes with an independent watermark
- migrate legacy adult/spam block entries into recoverable category placeholders

## Verification
- gofmt check
- go vet ./...
- go test -race ./...
- npm run lint
- npm run build
- bash -n scripts/sync-to-remote.sh
- desktop/mobile visual QA: 94/100
- independent code review: approved

## Risk
Live LLM provider responses and production SSH database sync were not exercised.