### PR TITLE
SQLite FTS5 search and hot-query caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,14 +142,33 @@ npm run dev                  # 开发
 
 ## DoS 防护
 
-搜索是无鉴权接口，而每次关键词查询都是两遍全表扫描（SQLite 单连接），所以 API 层内置了四道闸门，全部可用环境变量调整（见上表）：
+搜索是无鉴权接口。关键词查询使用 SQLite FTS5 倒排索引，但计数、深分页和不足三个字符的短词仍可能较贵，因此 API 层内置了四道闸门，全部可用环境变量调整（见上表）：
 
 - **每 IP 限流**：令牌桶（默认持续 3 req/s、突发 30），超出返回 429 + `Retry-After`。真实客户端 IP 只信任来自回环/内网地址（反向代理或同机 Next SSR 进程）的 `X-Forwarded-For`，公网直连时伪造头无效；IPv6 按 /64 计桶，防止单机用整段地址刷新桶。`/api/healthz` 不限流，监控和部署健康检查不会被洪水挤掉。
 - **搜索准入**：并发搜索上限（默认 16），等不到槽位（1 秒）直接 503 甩负载——SQLite 只有一个连接，排队再深也只是白占内存。
-- **单查询预算**：每次搜索默认 10s 超时，客户端断开即取消，慢查询不会继续占着数据库；关键词最多取前 8 个（每个关键词都让每行多算两次 LIKE），翻页深度上限 10000 行（`OFFSET` 越深扫描越贵），查询串按 UTF-8 边界截断到 200 字节。
+- **单查询预算**：每次搜索默认 10s 超时，客户端断开即取消，慢查询不会继续占着数据库；关键词最多取前 8 个，翻页深度上限 10000 行（`OFFSET` 越深扫描越贵），查询串按 UTF-8 边界截断到 200 字节。
 - **HTTP 层**：Read/Write/Idle 超时加 16 KB 请求头上限，挡 slowloris 和超大头攻击。
 
-另外 `/api/stats` 和首页总数走 10 秒 TTL 的单飞缓存（并发未命中只有一个请求去查库），聚合扫描每周期最多一次；`created_at` 索引让空查询（首页默认请求）从全表排序变成走索引取前 20 行。
+另外 `/api/stats`、首页总数和关键词结果页都走 10 秒 TTL 的单飞缓存（同一个热词并发未命中只有一个请求去查库）；关键词缓存最多保留 256 页，避免无界占用内存。`created_at` 索引让空查询（首页默认请求）从全表排序变成走索引取前 20 行。
+
+### SQLite 索引
+
+启动时会自动创建 `created_at` 普通索引和 FTS5 trigram 全文索引，并为已有数据做一次回填：
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_torrents_created
+    ON torrents(created_at DESC);
+
+CREATE VIRTUAL TABLE torrents_fts USING fts5(
+    name,
+    clean_name,
+    content='torrents',
+    content_rowid='rowid',
+    tokenize='trigram case_sensitive 0'
+);
+```
+
+插入、删除以及 `clean_name` 更新由数据库触发器同步到倒排索引。三字及以上的关键词使用 `MATCH`，按 FTS5 相关度、再按收录时间排序；一到两个字符没有 trigram，保留 `LIKE` 兼容路径。长短词混合时，短词只扫描已经被 FTS 缩小的候选集。
 
 前端 SSR 请求会把入站的 `X-Forwarded-For` / `X-Real-IP` 透传给后端，限流按真实访客计——注意反向代理需设置这两个头（nginx: `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;`）。
 

--- a/server/internal/api/api.go
+++ b/server/internal/api/api.go
@@ -32,6 +32,8 @@ const (
 	defaultMaxInflight   = 16
 	defaultSearchTimeout = 10 * time.Second
 	defaultStatsTTL      = 10 * time.Second
+	defaultSearchTTL     = 10 * time.Second
+	maxSearchCacheItems  = 256
 )
 
 // Options tunes the API's DoS defenses. Zero values pick safe defaults,
@@ -50,6 +52,9 @@ type Options struct {
 	// StatsTTL is how long stats and total-count responses are served from
 	// cache. Stats hit four aggregate queries; caching makes them O(1).
 	StatsTTL time.Duration
+	// SearchCacheTTL caches successful keyword result pages. Repeated hot
+	// queries are single-flighted so only one request reaches SQLite.
+	SearchCacheTTL time.Duration
 	// ScraperStatus, when non-nil, adds a "scraper" section to /api/stats.
 	ScraperStatus func() ScraperStatus
 }
@@ -100,6 +105,22 @@ type Server struct {
 	countMu   sync.Mutex
 	countVal  int
 	countAt   time.Time
+
+	searchMu    sync.Mutex
+	searchCache map[searchCacheKey]*searchCacheEntry
+}
+
+type searchCacheKey struct {
+	query          string
+	page, pageSize int
+}
+
+type searchCacheEntry struct {
+	items []store.Torrent
+	total int
+	at    time.Time
+	ready chan struct{}
+	err   error
 }
 
 // New builds the HTTP handler. crawlerStatus may be nil.
@@ -116,12 +137,16 @@ func New(st *store.Store, crawlerStatus func() CrawlerStatus, logger *log.Logger
 	if opts.StatsTTL <= 0 {
 		opts.StatsTTL = defaultStatsTTL
 	}
+	if opts.SearchCacheTTL <= 0 {
+		opts.SearchCacheTTL = defaultSearchTTL
+	}
 	s := &Server{
-		st:        st,
-		crawler:   crawlerStatus,
-		logger:    logger,
-		opts:      opts,
-		searchSem: make(chan struct{}, opts.MaxInflight),
+		st:          st,
+		crawler:     crawlerStatus,
+		logger:      logger,
+		opts:        opts,
+		searchSem:   make(chan struct{}, opts.MaxInflight),
+		searchCache: make(map[searchCacheKey]*searchCacheEntry),
 	}
 	if opts.RateRPS > 0 {
 		burst := opts.RateBurst
@@ -218,7 +243,14 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 			total, err = s.cachedCount(ctx)
 		}
 	} else {
-		items, total, err = s.st.Search(ctx, q, page, pageSize)
+		key := searchCacheKey{
+			query:    strings.Join(strings.Fields(q), " "),
+			page:     page,
+			pageSize: pageSize,
+		}
+		items, total, err = s.cachedSearch(ctx, key, func() ([]store.Torrent, int, error) {
+			return s.st.Search(ctx, q, page, pageSize)
+		})
 	}
 	if err != nil {
 		if ctx.Err() != nil {
@@ -248,6 +280,61 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		"page_size": pageSize,
 		"results":   results,
 	})
+}
+
+// cachedSearch returns a successful keyword page from a bounded TTL cache.
+// An entry with a non-nil ready channel is being loaded; concurrent callers
+// wait for that exact load instead of queuing duplicate SQLite scans.
+func (s *Server) cachedSearch(
+	ctx context.Context,
+	key searchCacheKey,
+	load func() ([]store.Torrent, int, error),
+) ([]store.Torrent, int, error) {
+	s.searchMu.Lock()
+	if entry := s.searchCache[key]; entry != nil {
+		if entry.ready != nil {
+			ready := entry.ready
+			s.searchMu.Unlock()
+			select {
+			case <-ready:
+				return entry.items, entry.total, entry.err
+			case <-ctx.Done():
+				return nil, 0, ctx.Err()
+			}
+		}
+		if time.Since(entry.at) < s.opts.SearchCacheTTL {
+			items, total := entry.items, entry.total
+			s.searchMu.Unlock()
+			return items, total, nil
+		}
+		delete(s.searchCache, key)
+	}
+	if len(s.searchCache) >= maxSearchCacheItems {
+		var oldestKey searchCacheKey
+		var oldest time.Time
+		for candidate, entry := range s.searchCache {
+			if entry.ready == nil && (oldest.IsZero() || entry.at.Before(oldest)) {
+				oldestKey, oldest = candidate, entry.at
+			}
+		}
+		if !oldest.IsZero() {
+			delete(s.searchCache, oldestKey)
+		}
+	}
+	entry := &searchCacheEntry{ready: make(chan struct{})}
+	s.searchCache[key] = entry
+	s.searchMu.Unlock()
+
+	entry.items, entry.total, entry.err = load()
+	s.searchMu.Lock()
+	entry.at = time.Now()
+	if entry.err != nil {
+		delete(s.searchCache, key)
+	}
+	close(entry.ready)
+	entry.ready = nil
+	s.searchMu.Unlock()
+	return entry.items, entry.total, entry.err
 }
 
 // cachedCount returns the total torrent count, at most StatsTTL stale.

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -5,7 +5,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"dhtsearch/server/internal/filter"
 	"dhtsearch/server/internal/store"
@@ -102,6 +105,49 @@ func TestSearchClampsDeepPagination(t *testing.T) {
 	m := getJSON(t, base+"/api/search?q=&page=99999999&page_size=100")
 	if got, want := m["page"].(float64), float64(maxOffset/100+1); got != want {
 		t.Fatalf("page = %v, want clamped to %v", got, want)
+	}
+}
+
+func TestKeywordSearchCacheSingleFlights(t *testing.T) {
+	s := &Server{
+		opts:        Options{SearchCacheTTL: time.Minute},
+		searchCache: make(map[searchCacheKey]*searchCacheEntry),
+	}
+	key := searchCacheKey{query: "popular", page: 1, pageSize: 20}
+	var loads atomic.Int32
+	release := make(chan struct{})
+	load := func() ([]store.Torrent, int, error) {
+		loads.Add(1)
+		<-release
+		return []store.Torrent{{InfoHash: "aa"}}, 1, nil
+	}
+
+	const callers = 12
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for range callers {
+		go func() {
+			defer wg.Done()
+			items, total, err := s.cachedSearch(t.Context(), key, load)
+			if err != nil || total != 1 || len(items) != 1 {
+				t.Errorf("cachedSearch = %v, %d, %v", items, total, err)
+			}
+		}()
+	}
+	for loads.Load() == 0 {
+		time.Sleep(time.Millisecond)
+	}
+	close(release)
+	wg.Wait()
+	if got := loads.Load(); got != 1 {
+		t.Fatalf("loads = %d, want 1", got)
+	}
+
+	if _, _, err := s.cachedSearch(t.Context(), key, load); err != nil {
+		t.Fatal(err)
+	}
+	if got := loads.Load(); got != 1 {
+		t.Fatalf("cached reload count = %d, want 1", got)
 	}
 }
 

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/klauspost/compress/zstd"
 	_ "modernc.org/sqlite"
@@ -120,7 +121,57 @@ CREATE TABLE IF NOT EXISTS blocked (
 		db.Close()
 		return nil, fmt.Errorf("create created_at index: %w", err)
 	}
+	if err := ensureFTS5(db); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("initialize full-text index: %w", err)
+	}
 	return &Store{db: db}, nil
+}
+
+// ensureFTS5 creates an external-content trigram index over both title forms.
+// Trigrams preserve the substring behavior users had with LIKE while letting
+// SQLite use an inverted index for terms of three or more Unicode codepoints.
+// The migration marker makes the one-time rebuild restart-safe: a crash before
+// the marker merely repeats an idempotent rebuild on the next Open.
+func ensureFTS5(db *sql.DB) error {
+	const schema = `
+CREATE VIRTUAL TABLE IF NOT EXISTS torrents_fts USING fts5(
+	name,
+	clean_name,
+	content='torrents',
+	content_rowid='rowid',
+	tokenize='trigram case_sensitive 0'
+);
+CREATE TRIGGER IF NOT EXISTS torrents_fts_ai AFTER INSERT ON torrents BEGIN
+	INSERT INTO torrents_fts(rowid, name, clean_name)
+	VALUES (new.rowid, new.name, new.clean_name);
+END;
+CREATE TRIGGER IF NOT EXISTS torrents_fts_ad AFTER DELETE ON torrents BEGIN
+	INSERT INTO torrents_fts(torrents_fts, rowid, name, clean_name)
+	VALUES ('delete', old.rowid, old.name, old.clean_name);
+END;
+CREATE TRIGGER IF NOT EXISTS torrents_fts_au AFTER UPDATE OF name, clean_name ON torrents BEGIN
+	INSERT INTO torrents_fts(torrents_fts, rowid, name, clean_name)
+	VALUES ('delete', old.rowid, old.name, old.clean_name);
+	INSERT INTO torrents_fts(rowid, name, clean_name)
+	VALUES (new.rowid, new.name, new.clean_name);
+END;`
+	if _, err := db.Exec(schema); err != nil {
+		return err
+	}
+
+	var migrated int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM stats WHERE key = 'fts5_trigram_v1'`).Scan(&migrated); err != nil {
+		return err
+	}
+	if migrated != 0 {
+		return nil
+	}
+	if _, err := db.Exec(`INSERT INTO torrents_fts(torrents_fts) VALUES ('rebuild')`); err != nil {
+		return err
+	}
+	_, err := db.Exec(`INSERT OR IGNORE INTO stats(key, value) VALUES ('fts5_trigram_v1', 1)`)
+	return err
 }
 
 // Shared zstd coders. EncodeAll/DecodeAll on a nil-stream coder are safe for
@@ -266,34 +317,60 @@ const selectCols = `SELECT info_hash, IIF(clean_name <> '', clean_name, name),
 	total_size, file_count, files, created_at FROM torrents`
 
 // Search finds torrents whose name contains every space-separated keyword
-// of query (AND semantics), newest first. An empty query returns the latest
-// additions. page is 1-based; pageSize must be > 0. ctx bounds the queries:
-// keyword matching is a full-table scan, so callers must be able to cut it
-// off when the client hangs up or a deadline passes.
+// of query (AND semantics), ranked by relevance and then recency. Terms of
+// three or more codepoints use the FTS5 trigram index. Short terms retain the
+// old LIKE behavior; when mixed with longer terms they only scan the rows
+// already narrowed by FTS. An empty query returns the latest additions.
 func (s *Store) Search(ctx context.Context, query string, page, pageSize int) (items []Torrent, total int, err error) {
 	if page < 1 {
 		page = 1
 	}
-	where, args := "", []interface{}{}
 	keywords := strings.Fields(query)
 	if len(keywords) > maxKeywords {
 		keywords = keywords[:maxKeywords]
 	}
-	if len(keywords) > 0 {
-		var conds []string
-		for _, kw := range keywords {
-			// Match either title: the raw one so trimming can never hide a
-			// result, and the cleaned one so a phrase that only reads
-			// contiguously once the ad text is gone still matches.
-			conds = append(conds, "(name LIKE ? ESCAPE '\\' OR clean_name LIKE ? ESCAPE '\\')")
-			args = append(args, "%"+escapeLike(kw)+"%", "%"+escapeLike(kw)+"%")
+	if len(keywords) == 0 {
+		if err = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM torrents`).Scan(&total); err != nil {
+			return nil, 0, err
 		}
-		where = " WHERE " + strings.Join(conds, " AND ")
+		rows, qerr := s.db.QueryContext(ctx,
+			selectCols+` ORDER BY created_at DESC LIMIT ? OFFSET ?`, pageSize, (page-1)*pageSize)
+		if qerr != nil {
+			return nil, 0, qerr
+		}
+		items, err = scanTorrents(rows)
+		return items, total, err
 	}
-	if err = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM torrents`+where, args...).Scan(&total); err != nil {
+
+	var ftsTerms, shortTerms []string
+	for _, kw := range keywords {
+		if utf8.RuneCountInString(kw) >= 3 {
+			ftsTerms = append(ftsTerms, `"`+strings.ReplaceAll(kw, `"`, `""`)+`"`)
+		} else {
+			shortTerms = append(shortTerms, kw)
+		}
+	}
+
+	from := ` FROM torrents t`
+	var conds []string
+	args := make([]interface{}, 0, 1+len(shortTerms)*2)
+	order := ` ORDER BY t.created_at DESC`
+	if len(ftsTerms) > 0 {
+		from = ` FROM torrents_fts JOIN torrents t ON t.rowid = torrents_fts.rowid`
+		conds = append(conds, `torrents_fts MATCH ?`)
+		args = append(args, strings.Join(ftsTerms, " AND "))
+		order = ` ORDER BY bm25(torrents_fts), t.created_at DESC`
+	}
+	for _, kw := range shortTerms {
+		conds = append(conds, `(t.name LIKE ? ESCAPE '\\' OR t.clean_name LIKE ? ESCAPE '\\')`)
+		args = append(args, "%"+escapeLike(kw)+"%", "%"+escapeLike(kw)+"%")
+	}
+	where := " WHERE " + strings.Join(conds, " AND ")
+	if err = s.db.QueryRowContext(ctx, `SELECT COUNT(*)`+from+where, args...).Scan(&total); err != nil {
 		return nil, 0, err
 	}
-	q := selectCols + where + ` ORDER BY created_at DESC LIMIT ? OFFSET ?`
+	q := `SELECT t.info_hash, IIF(t.clean_name <> '', t.clean_name, t.name),
+		t.total_size, t.file_count, t.files, t.created_at` + from + where + order + ` LIMIT ? OFFSET ?`
 	rows, err := s.db.QueryContext(ctx, q, append(args, pageSize, (page-1)*pageSize)...)
 	if err != nil {
 		return nil, 0, err

--- a/server/internal/store/store_test.go
+++ b/server/internal/store/store_test.go
@@ -321,6 +321,57 @@ func TestSetCleanNamesReplacesDisplayNameOnly(t *testing.T) {
 	}
 }
 
+func TestFTS5BackfillAndTriggerSync(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fts.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE torrents (
+		info_hash TEXT PRIMARY KEY, name TEXT NOT NULL, total_size INTEGER NOT NULL,
+		file_count INTEGER NOT NULL, files BLOB NOT NULL, created_at INTEGER NOT NULL,
+		reviewed_at INTEGER NOT NULL DEFAULT 0, clean_name TEXT NOT NULL DEFAULT ''
+	);
+	CREATE TABLE stats (key TEXT PRIMARY KEY, value INTEGER NOT NULL);
+	CREATE TABLE blocked (
+		info_hash TEXT PRIMARY KEY, reason TEXT NOT NULL, name TEXT NOT NULL, created_at INTEGER NOT NULL
+	);
+	INSERT INTO torrents VALUES ('old', '前缀电影资源后缀', 1, 0, '[]', 100, 0, '');`); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	db.Close()
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	items, total, err := s.Search(t.Context(), "电影资", 1, 10)
+	if err != nil || total != 1 || items[0].InfoHash != "old" {
+		t.Fatalf("backfilled substring search: items=%v total=%d err=%v", items, total, err)
+	}
+	if err := s.Upsert(Torrent{InfoHash: "new", Name: "ordinary title", TotalSize: 2, CreatedAt: 200}); err != nil {
+		t.Fatal(err)
+	}
+	if _, total, err = s.Search(t.Context(), "ordinary", 1, 10); err != nil || total != 1 {
+		t.Fatalf("insert trigger search: total=%d err=%v", total, err)
+	}
+	if _, err := s.SetCleanNames(map[string]string{"new": "目标标题资源"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, total, err = s.Search(t.Context(), "目标标", 1, 10); err != nil || total != 1 {
+		t.Fatalf("update trigger search: total=%d err=%v", total, err)
+	}
+	if _, err := s.Block([]string{"new"}, []string{"ordinary title"}, "spam", 300); err != nil {
+		t.Fatal(err)
+	}
+	if _, total, err = s.Search(t.Context(), "目标标", 1, 10); err != nil || total != 0 {
+		t.Fatalf("delete trigger search: total=%d err=%v", total, err)
+	}
+}
+
 func TestSetCleanNamesEmptyMapIsNoOp(t *testing.T) {
 	s := openTest(t)
 	n, err := s.SetCleanNames(nil)


### PR DESCRIPTION
## Summary
- add a trigger-maintained FTS5 trigram index for raw and cleaned titles
- backfill existing databases once and keep insert/update/delete changes synchronized
- preserve one/two-character LIKE compatibility while ranking indexed terms by relevance
- add a bounded 10-second single-flight cache for hot keyword pages

## Verification
- gofmt check
- go vet ./...
- go test -race ./...
- independent code review: approved

## Risk
Initial startup performs a one-time FTS rebuild; production-scale rebuild duration is not measured.