### PR TITLE
Publish reproducible cross-platform binaries

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -1,0 +1,148 @@
+name: Binary Release
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build cross-platform archives
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      artifact_name: ${{ steps.meta.outputs.artifact_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
+
+      - name: Compute artifact metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            version="${GITHUB_REF_NAME}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            version="pr-${{ github.event.pull_request.number }}-${GITHUB_SHA::7}"
+          else
+            version="manual-${GITHUB_SHA::7}"
+          fi
+
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "artifact_name=dhtsearch-server-${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build reproducible archives
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${{ steps.meta.outputs.version }}"
+          dist_dir="${RUNNER_TEMP}/dist"
+          fixed_timestamp=200001010000
+          targets=(
+            "linux/amd64"
+            "linux/arm64"
+            "darwin/amd64"
+            "darwin/arm64"
+            "windows/amd64"
+            "windows/arm64"
+          )
+
+          rm -rf "${dist_dir}"
+          mkdir -p "${dist_dir}"
+
+          for target in "${targets[@]}"; do
+            IFS=/ read -r goos goarch <<< "${target}"
+            base="dhtsearch-server_${version}_${goos}_${goarch}"
+            stage_dir="${RUNNER_TEMP}/${base}"
+            binary_name="dhtsearch-server"
+
+            if [[ "${goos}" == "windows" ]]; then
+              binary_name="${binary_name}.exe"
+            fi
+
+            rm -rf "${stage_dir}"
+            mkdir -p "${stage_dir}"
+
+            (
+              cd server
+              GOOS="${goos}" GOARCH="${goarch}" CGO_ENABLED=0 \
+                go build \
+                  -trimpath \
+                  -buildvcs=false \
+                  -ldflags='-buildid=' \
+                  -o "${stage_dir}/${binary_name}" \
+                  ./cmd/server
+            )
+
+            cp LICENSE "${stage_dir}/LICENSE"
+            TZ=UTC touch -t "${fixed_timestamp}" \
+              "${stage_dir}/${binary_name}" \
+              "${stage_dir}/LICENSE"
+
+            tar \
+              --sort=name \
+              --mtime='UTC 2000-01-01' \
+              --owner=0 \
+              --group=0 \
+              --numeric-owner \
+              -C "${stage_dir}" \
+              -czf "${dist_dir}/${base}.tar.gz" \
+              LICENSE \
+              "${binary_name}"
+          done
+
+          (
+            cd "${dist_dir}"
+            sha256sum ./*.tar.gz > SHA256SUMS
+          )
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.meta.outputs.artifact_name }}
+          path: |
+            ${{ runner.temp }}/dist/*.tar.gz
+            ${{ runner.temp }}/dist/SHA256SUMS
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download packaged archives
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: dist
+
+      - name: Publish immutable release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${{ needs.build.outputs.version }}"
+
+          if gh release view "${version}" >/dev/null 2>&1; then
+            echo "release ${version} already exists; refusing to replace immutable assets" >&2
+            exit 1
+          fi
+
+          gh release create "${version}" dist/* --generate-notes

--- a/README.md
+++ b/README.md
@@ -134,6 +134,26 @@ npm run dev                  # 开发
 # 或 npm run build && npm run start   # 生产
 ```
 
+## 二进制发布
+
+仓库内置了 GitHub Actions 工作流 `.github/workflows/binary-release.yml`，用于打包
+`dhtsearch-server` 的跨平台二进制归档：
+
+- `pull_request` 与 `workflow_dispatch`：只构建并上传 workflow artifact，不创建 GitHub Release
+- `push` 到 `v*` tag（如 `v1.2.3`）：构建相同产物，并把它们发布到对应的 GitHub Release
+- 当前打包目标：`linux/amd64`、`linux/arm64`、`darwin/amd64`、`darwin/arm64`、`windows/amd64`、`windows/arm64`
+
+每个目标都会生成一个 `tar.gz` 归档，命名格式如下：
+
+```text
+dhtsearch-server_<version>_<goos>_<goarch>.tar.gz
+```
+
+同时会附带一个 `SHA256SUMS` 文件，包含全部归档的校验和。Windows 归档内的可执行文件名为
+`dhtsearch-server.exe`，其余平台为 `dhtsearch-server`。构建使用 `server/go.mod` 里的 Go
+版本，并以 `CGO_ENABLED=0`、`-trimpath`、`-buildvcs=false` 与固定归档时间戳打包，尽量保证
+可复现输出。
+
 ## API
 
 - `GET /api/search?q=xx&page=1&page_size=20` — 搜索（q 为空返回最新收录），结果含拼好的 magnet 链接


### PR DESCRIPTION
## Summary
- build Linux, macOS, and Windows archives for amd64 and arm64
- produce deterministic archive metadata and SHA256SUMS
- upload artifacts for PR/manual runs and publish immutable assets for v* tags
- use minimal permissions and refuse to overwrite an existing release

## Verification
- actionlint
- local cross-build/package loop for all six targets
- Windows amd64/arm64 probes
- reproducibility spot-check
- independent supply-chain review: approved

## Risk
The GitHub release upload path has not been exercised with a live version tag.