### PR TITLE
Add registry-first Docker Compose deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+name: dhtsearch
+
+services:
+  dhtsearch:
+    image: ${DHTSEARCH_IMAGE:-ghcr.io/madeye/dhtsearch:latest}
+    pull_policy: always
+    init: true
+    restart: unless-stopped
+    stop_grace_period: 30s
+    ports:
+      - "${WEB_PORT:-3000}:3000"
+      - "${API_PORT:-8080}:8080"
+      - "${DHT_UDP_PORT:-6881}:6881/udp"
+    environment:
+      HTTP_ADDR: ":8080"
+      DB_PATH: "/data/dhtsearch.db"
+      DHT_PORT: "6881"
+    env_file:
+      - path: .env
+        required: false
+    volumes:
+      - dhtsearch-data:/data
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+volumes:
+  dhtsearch-data:


### PR DESCRIPTION
## Summary
- add a production `docker-compose.yml` that consumes the published GHCR image without local builds
- persist SQLite data in a named volume
- expose web, API, and DHT UDP ports with host-side overrides
- load `.env` only when present and cap json-file log growth
- support forks through the `DHTSEARCH_IMAGE` override

## Usage
```bash
DHTSEARCH_IMAGE=ghcr.io/ca-x/dhtsearch:latest docker compose up -d
```

## Verification
- Ruby YAML parse and structural assertions
- `git diff --check`

## Dependency
This deployment file consumes the image introduced by #29. It intentionally has no `build:` section.

## Note
No local Docker build/run was performed per project-owner direction.