### PR TITLE
web: add Google Analytics gtag (ID via env)

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -10,6 +11,8 @@ export const metadata: Metadata = {
     "干净、无广告的磁力链接搜索引擎。基于 DHT 网络实时收录，自动过滤成人内容与垃圾信息。",
 };
 
+const gaId = process.env.NEXT_PUBLIC_GA_ID;
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -19,6 +22,20 @@ export default function RootLayout({
     <html lang="zh-CN" className="h-full">
       <body className="flex min-h-full flex-col bg-zinc-950 text-zinc-100 antialiased">
         {children}
+        {gaId && (
+          <>
+            <Script
+              src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+              strategy="afterInteractive"
+            />
+            <Script id="gtag-init" strategy="afterInteractive">
+              {`window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${gaId}');`}
+            </Script>
+          </>
+        )}
       </body>
     </html>
   );

--- a/web/env.example
+++ b/web/env.example
@@ -1,0 +1,10 @@
+# Copy to .env.local and fill in. .env.local is gitignored — never commit
+# real values (a pre-commit hook also blocks .env* paths).
+#   cp env.example .env.local
+
+# Backend API base URL (Go service)
+NEXT_PUBLIC_API_BASE=http://localhost:8080
+
+# Google Analytics measurement ID (G-XXXXXXXXXX). Inlined at build time;
+# leave empty to disable analytics entirely (no gtag scripts rendered).
+NEXT_PUBLIC_GA_ID=


### PR DESCRIPTION
Adds the Google tag (gtag.js) to the root layout using `next/script` with `afterInteractive` strategy.

The measurement ID is configurable via `NEXT_PUBLIC_GA_ID`:
- When unset/empty, no gtag scripts are rendered at all.
- Documented in `web/env.example` (dot-less filename, matching the root `env.example`, because the pre-commit hook blocks `.env*` paths).
- The real ID (`G-81VS29BC2Z`) lives in the gitignored `web/.env.local` on the build machine and is inlined at build time (verified present in the standalone server output).

Verified locally: `npm run lint` and `npm run build` pass.