### PR TITLE
Add Douban trending movie/TV quick-search chips to homepage

### DIFF
--- a/env.example
+++ b/env.example
@@ -69,6 +69,14 @@ SCRAPE_ENABLED=true
 # built for this volume.
 # TRACKERS=udp://tracker.opentrackr.org:1337/announce,udp://open.demonii.com:1337/announce,udp://tracker.torrent.eu.org:451/announce,udp://exodus.desync.com:6969/announce
 
+# --- Douban trending (homepage quick-search chips) ---
+# Hourly fetch of Douban's hot movie/TV titles (unofficial JSON endpoint;
+# one request per list per interval). On failure the last good list keeps
+# serving; if it never succeeds the homepage just hides the section.
+# TRENDING_ENABLED=true
+# TRENDING_INTERVAL=1h
+# TRENDING_LIMIT=10
+
 # --- Indexing ---
 # Skip torrents whose total size is below this many bytes (default 100 MiB).
 MIN_TORRENT_SIZE=104857600

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -22,6 +22,7 @@ import (
 	"dhtsearch/server/internal/moderator"
 	"dhtsearch/server/internal/scraper"
 	"dhtsearch/server/internal/store"
+	"dhtsearch/server/internal/trending"
 )
 
 // defaultTrackers are large, long-lived open trackers. They serve both
@@ -142,6 +143,14 @@ func main() {
 		"max concurrent search queries before shedding load")
 	searchTimeout := flag.Duration("search-timeout", envDuration("SEARCH_TIMEOUT", 10*time.Second),
 		"database time budget for one search request")
+
+	// Douban trending quick-search chips.
+	trendEnabled := flag.Bool("trending", envBool("TRENDING_ENABLED", true),
+		"periodically fetch Douban hot movie/TV titles for /api/trending")
+	trendInterval := flag.Duration("trending-interval", envDuration("TRENDING_INTERVAL", time.Hour),
+		"how often to refresh the Douban trending lists")
+	trendLimit := flag.Int("trending-limit", envInt("TRENDING_LIMIT", 10),
+		"titles to keep per trending list")
 
 	// LLM moderation pass.
 	modEnabled := flag.Bool("moderate", envBool("MODERATION_ENABLED", true),
@@ -289,6 +298,25 @@ func main() {
 		}
 	}
 
+	// Douban trending fetcher for the homepage quick-search chips.
+	var trendFn func() api.Trending
+	if *trendEnabled {
+		svc := trending.New(trending.Config{
+			Interval: *trendInterval,
+			Limit:    *trendLimit,
+			Logger:   logger,
+		})
+		go svc.Run(ctx)
+		trendFn = func() api.Trending {
+			snap := svc.Get()
+			t := api.Trending{Movies: snap.Movies, TV: snap.TV}
+			if !snap.UpdatedAt.IsZero() {
+				t.UpdatedAt = snap.UpdatedAt.Unix()
+			}
+			return t
+		}
+	}
+
 	// Mirror the crawler's in-memory seen count and the fetch outcome
 	// counters into the stats table periodically. Both are process-local and
 	// monotonic, so only the delta since the last tick is applied.
@@ -333,6 +361,7 @@ func main() {
 			MaxInflight:   *searchInflight,
 			SearchTimeout: *searchTimeout,
 			ScraperStatus: scraperStatus(scr),
+			Trending:      trendFn,
 		}).Handler(),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       15 * time.Second,

--- a/server/internal/api/api.go
+++ b/server/internal/api/api.go
@@ -52,6 +52,17 @@ type Options struct {
 	StatsTTL time.Duration
 	// ScraperStatus, when non-nil, adds a "scraper" section to /api/stats.
 	ScraperStatus func() ScraperStatus
+	// Trending, when non-nil, backs /api/trending. Nil (feature disabled)
+	// makes the endpoint serve empty lists so the frontend degrades quietly.
+	Trending func() Trending
+}
+
+// Trending is the payload for /api/trending: Douban's current hot movie and
+// TV titles, for the homepage's quick-search chips.
+type Trending struct {
+	Movies    []string `json:"movies"`
+	TV        []string `json:"tv"`
+	UpdatedAt int64    `json:"updated_at"`
 }
 
 // CrawlerStatus describes the crawler for the stats endpoint. The sampler
@@ -133,6 +144,7 @@ func New(st *store.Store, crawlerStatus func() CrawlerStatus, logger *log.Logger
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/search", s.handleSearch)
 	mux.HandleFunc("GET /api/stats", s.handleStats)
+	mux.HandleFunc("GET /api/trending", s.handleTrending)
 	mux.HandleFunc("GET /api/healthz", s.handleHealth)
 	s.mux = mux
 	return s
@@ -338,6 +350,21 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	}
 	s.statsBody, s.statsAt = body, time.Now()
 	writeRawJSON(w, http.StatusOK, body)
+}
+
+func (s *Server) handleTrending(w http.ResponseWriter, r *http.Request) {
+	t := Trending{Movies: []string{}, TV: []string{}}
+	if s.opts.Trending != nil {
+		got := s.opts.Trending()
+		if got.Movies != nil {
+			t.Movies = got.Movies
+		}
+		if got.TV != nil {
+			t.TV = got.TV
+		}
+		t.UpdatedAt = got.UpdatedAt
+	}
+	writeJSON(w, http.StatusOK, t)
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/trending/trending.go
+++ b/server/internal/trending/trending.go
@@ -1,0 +1,174 @@
+// Package trending periodically fetches Douban's trending movie and TV
+// lists and caches the titles, feeding the homepage's quick-search chips.
+//
+// Douban has no official API; this uses the JSON endpoint its own frontend
+// calls (movie.douban.com/j/search_subjects). One request per list per
+// interval is far below any plausible abuse threshold, but the endpoint can
+// still change or disappear at any time — so every failure mode degrades to
+// "keep serving the last good list", and an empty snapshot just means the
+// homepage renders no trending section.
+package trending
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+const (
+	defaultBaseURL  = "https://movie.douban.com"
+	defaultInterval = time.Hour
+	defaultLimit    = 10
+	fetchTimeout    = 20 * time.Second
+	// maxBody bounds how much of a response is read; the real payload for 10
+	// subjects is ~4 KB, so 1 MB means "something is very wrong upstream".
+	maxBody = 1 << 20
+	// browserUA is required: Douban serves the JSON endpoint to browsers and
+	// rejects obvious non-browser clients.
+	browserUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+		"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+)
+
+// Config tunes the fetcher. Zero values pick the defaults above.
+type Config struct {
+	// Interval between refreshes.
+	Interval time.Duration
+	// Limit is how many titles to keep per list.
+	Limit int
+	// BaseURL overrides the Douban origin (tests point it at a stub).
+	BaseURL string
+	Logger  *log.Logger
+}
+
+// Snapshot is the current trending state. Slices are never nil.
+type Snapshot struct {
+	Movies    []string
+	TV        []string
+	UpdatedAt time.Time
+}
+
+// Service fetches and caches the trending lists.
+type Service struct {
+	cfg    Config
+	client *http.Client
+
+	mu   sync.RWMutex
+	snap Snapshot
+}
+
+// New builds a Service; call Run to start refreshing.
+func New(cfg Config) *Service {
+	if cfg.Interval <= 0 {
+		cfg.Interval = defaultInterval
+	}
+	if cfg.Limit <= 0 {
+		cfg.Limit = defaultLimit
+	}
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = defaultBaseURL
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = log.Default()
+	}
+	return &Service{
+		cfg:    cfg,
+		client: &http.Client{Timeout: fetchTimeout},
+	}
+}
+
+// Get returns the latest snapshot. Empty lists mean no successful fetch yet.
+func (s *Service) Get() Snapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.snap
+}
+
+// Run refreshes immediately and then every Interval until ctx is done.
+func (s *Service) Run(ctx context.Context) {
+	s.refresh(ctx)
+	t := time.NewTicker(s.cfg.Interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.refresh(ctx)
+		}
+	}
+}
+
+// refresh fetches both lists. A list that fails keeps its previous value, so
+// one bad response never blanks the homepage section.
+func (s *Service) refresh(ctx context.Context) {
+	movies, errM := s.fetchList(ctx, "movie")
+	tv, errT := s.fetchList(ctx, "tv")
+	if errM != nil {
+		s.cfg.Logger.Printf("trending: movie fetch: %v", errM)
+	}
+	if errT != nil {
+		s.cfg.Logger.Printf("trending: tv fetch: %v", errT)
+	}
+	if errM != nil && errT != nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if errM == nil {
+		s.snap.Movies = movies
+	}
+	if errT == nil {
+		s.snap.TV = tv
+	}
+	s.snap.UpdatedAt = time.Now()
+}
+
+// fetchList pulls one 热门 list ("movie" or "tv") and returns its titles.
+func (s *Service) fetchList(ctx context.Context, typ string) ([]string, error) {
+	u := fmt.Sprintf("%s/j/search_subjects?type=%s&tag=%s&page_limit=%d&page_start=0",
+		s.cfg.BaseURL, typ, url.QueryEscape("热门"), s.cfg.Limit)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", browserUA)
+	req.Header.Set("Referer", "https://movie.douban.com/")
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBody))
+	if err != nil {
+		return nil, err
+	}
+	var payload struct {
+		Subjects []struct {
+			Title string `json:"title"`
+		} `json:"subjects"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	titles := make([]string, 0, len(payload.Subjects))
+	for _, sub := range payload.Subjects {
+		if sub.Title != "" {
+			titles = append(titles, sub.Title)
+		}
+	}
+	if len(titles) == 0 {
+		// A 200 with no subjects usually means Douban changed the response
+		// shape or is soft-blocking; treat as failure to keep the last list.
+		return nil, fmt.Errorf("no titles in response")
+	}
+	return titles, nil
+}

--- a/server/internal/trending/trending_test.go
+++ b/server/internal/trending/trending_test.go
@@ -1,0 +1,61 @@
+package trending
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestFetchAndKeepLastGood(t *testing.T) {
+	var fail bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fail {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		typ := r.URL.Query().Get("type")
+		fmt.Fprintf(w, `{"subjects":[{"title":"%s-one"},{"title":"%s-two"}]}`, typ, typ)
+	}))
+	defer srv.Close()
+
+	svc := New(Config{BaseURL: srv.URL, Interval: time.Hour})
+	svc.refresh(context.Background())
+
+	snap := svc.Get()
+	if got := snap.Movies; len(got) != 2 || got[0] != "movie-one" {
+		t.Fatalf("movies = %v", got)
+	}
+	if got := snap.TV; len(got) != 2 || got[1] != "tv-two" {
+		t.Fatalf("tv = %v", got)
+	}
+	if snap.UpdatedAt.IsZero() {
+		t.Fatal("UpdatedAt not set")
+	}
+
+	// Upstream breaks: the previous snapshot must survive untouched.
+	fail = true
+	before := svc.Get()
+	svc.refresh(context.Background())
+	after := svc.Get()
+	if len(after.Movies) != 2 || len(after.TV) != 2 {
+		t.Fatalf("snapshot lost after failed refresh: %+v", after)
+	}
+	if !after.UpdatedAt.Equal(before.UpdatedAt) {
+		t.Fatal("UpdatedAt advanced on a fully failed refresh")
+	}
+}
+
+func TestEmptySubjectsIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"subjects":[]}`)
+	}))
+	defer srv.Close()
+
+	svc := New(Config{BaseURL: srv.URL})
+	if _, err := svc.fetchList(context.Background(), "movie"); err == nil {
+		t.Fatal("expected error for empty subjects")
+	}
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,10 +1,30 @@
-import { fetchStats } from "@/lib/api";
+import Link from "next/link";
+import { fetchStats, fetchTrending } from "@/lib/api";
 import { formatCount } from "@/lib/format";
 import SearchBox from "@/components/SearchBox";
 import DigitalOceanBadge from "@/components/DigitalOceanBadge";
 
+function TrendingRow({ label, titles }: { label: string; titles: string[] }) {
+  return (
+    <div className="mt-3 flex flex-wrap items-center justify-center gap-2">
+      <span className="text-xs text-zinc-500">{label}</span>
+      {titles.map((title) => (
+        <Link
+          key={title}
+          href={`/search?q=${encodeURIComponent(title)}`}
+          className="rounded-full border border-zinc-800 bg-zinc-900 px-3 py-1 text-xs text-zinc-300 transition-colors hover:border-emerald-700 hover:text-emerald-400"
+        >
+          {title}
+        </Link>
+      ))}
+    </div>
+  );
+}
+
 export default async function Home() {
-  const stats = await fetchStats();
+  const [stats, trending] = await Promise.all([fetchStats(), fetchTrending()]);
+  const movies = trending?.movies ?? [];
+  const tv = trending?.tv ?? [];
 
   return (
     <main className="flex flex-1 flex-col items-center justify-center px-4 py-16">
@@ -26,6 +46,16 @@ export default async function Home() {
         <p className="mt-4 text-center text-xs text-zinc-500">
           直接输入关键词搜索，留空则浏览最新收录的资源
         </p>
+
+        {(movies.length > 0 || tv.length > 0) && (
+          <div className="mt-8">
+            {movies.length > 0 && <TrendingRow label="热门电影" titles={movies} />}
+            {tv.length > 0 && <TrendingRow label="热门剧集" titles={tv} />}
+            <p className="mt-2 text-center text-[10px] text-zinc-600">
+              热门影视数据来自豆瓣
+            </p>
+          </div>
+        )}
       </div>
 
       <footer className="mt-16 text-center text-xs text-zinc-500">

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -82,6 +82,28 @@ export async function fetchSearch(
   return (await res.json()) as SearchResponse;
 }
 
+export interface TrendingResponse {
+  movies?: string[];
+  tv?: string[];
+  updated_at?: number;
+}
+
+export async function fetchTrending(): Promise<TrendingResponse | null> {
+  try {
+    // The backend refreshes hourly; revalidate keeps the homepage from
+    // hitting the API per request. No per-client IP headers here — they
+    // would fragment this shared cache into one entry per visitor.
+    const res = await fetch(`${API_BASE}/api/trending`, {
+      next: { revalidate: 300 },
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as TrendingResponse;
+  } catch {
+    // Trending is decorative — degrade to no section.
+    return null;
+  }
+}
+
 export async function fetchStats(): Promise<StatsResponse | null> {
   try {
     const res = await fetch(`${API_BASE}/api/stats`, {


### PR DESCRIPTION
Adds 热门电影 / 热门剧集 quick-search chips to the homepage, sourced from Douban's trending lists.

**Backend** (`server/internal/trending`):
- Fetches Douban's hot movie and TV lists hourly via the unofficial JSON endpoint (`movie.douban.com/j/search_subjects`) with a browser UA — verified working from the production server's IP.
- Caches titles in memory; a failed refresh keeps the last good list, so a Douban outage/block never breaks the site.
- New `GET /api/trending` returns `{movies, tv, updated_at}` (empty lists when disabled or not yet fetched).
- Knobs: `TRENDING_ENABLED` (default true), `TRENDING_INTERVAL` (1h), `TRENDING_LIMIT` (10) — documented in `env.example`.

**Frontend**:
- Homepage renders the titles as chips linking to `/search?q=<title>`, with a 豆瓣 attribution line; section is hidden entirely when there's no data (e.g. old backend, feature disabled).
- `fetchTrending` uses `revalidate: 300` and deliberately omits the per-client IP forwarding headers so the cache is shared across visitors.

**Testing**: unit tests for fetch/parse and keep-last-good behavior; `go vet`, `gofmt`, `go build`, `npm run lint`, `npm run build` all pass. Ran the full stack locally — chips render with live Douban data.