### PR TITLE
Trending: 欧美-only charts, English names as search keywords

### DIFF
--- a/env.example
+++ b/env.example
@@ -70,9 +70,11 @@ SCRAPE_ENABLED=true
 # TRACKERS=udp://tracker.opentrackr.org:1337/announce,udp://open.demonii.com:1337/announce,udp://tracker.torrent.eu.org:451/announce,udp://exodus.desync.com:6969/announce
 
 # --- Douban trending (homepage quick-search chips) ---
-# Hourly fetch of Douban's hot movie/TV titles (unofficial JSON endpoint;
-# one request per list per interval). On failure the last good list keeps
-# serving; if it never succeeds the homepage just hides the section.
+# Hourly fetch of Douban's trending Western movies (欧美 tag) and US TV
+# shows (美剧 tag), resolved to their English names via one extra
+# subject_abstract call per newly-charted title (cached by subject ID).
+# On failure the last good list keeps serving; if it never succeeds the
+# homepage just hides the section.
 # TRENDING_ENABLED=true
 # TRENDING_INTERVAL=1h
 # TRENDING_LIMIT=10

--- a/server/internal/trending/trending.go
+++ b/server/internal/trending/trending.go
@@ -1,12 +1,15 @@
-// Package trending periodically fetches Douban's trending movie and TV
-// lists and caches the titles, feeding the homepage's quick-search chips.
+// Package trending periodically fetches Douban's trending Western movie and
+// US-TV lists and caches the titles, feeding the homepage's quick-search
+// chips.
 //
-// Douban has no official API; this uses the JSON endpoint its own frontend
-// calls (movie.douban.com/j/search_subjects). One request per list per
-// interval is far below any plausible abuse threshold, but the endpoint can
-// still change or disappear at any time — so every failure mode degrades to
-// "keep serving the last good list", and an empty snapshot just means the
-// homepage renders no trending section.
+// Douban has no official API; this uses the JSON endpoints its own frontend
+// calls (movie.douban.com/j/search_subjects and /j/subject_abstract). The
+// list endpoint only carries Chinese titles, so each subject's English name
+// is resolved through one subject_abstract call, cached by subject ID —
+// steady-state cost is a couple of requests per interval for whatever newly
+// entered the charts. Every failure mode degrades to "keep serving the last
+// good list", and an empty snapshot just means the homepage renders no
+// trending section.
 package trending
 
 import (
@@ -17,8 +20,11 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
+	"unicode"
 )
 
 const (
@@ -26,11 +32,14 @@ const (
 	defaultInterval = time.Hour
 	defaultLimit    = 10
 	fetchTimeout    = 20 * time.Second
-	// maxBody bounds how much of a response is read; the real payload for 10
-	// subjects is ~4 KB, so 1 MB means "something is very wrong upstream".
+	// abstractDelay spaces out the per-subject metadata requests so a cold
+	// start doesn't burst-hammer Douban.
+	abstractDelay = 500 * time.Millisecond
+	// maxBody bounds how much of a response is read; the real payloads are a
+	// few KB, so 1 MB means "something is very wrong upstream".
 	maxBody = 1 << 20
-	// browserUA is required: Douban serves the JSON endpoint to browsers and
-	// rejects obvious non-browser clients.
+	// browserUA is required: Douban serves these JSON endpoints to browsers
+	// and rejects obvious non-browser clients.
 	browserUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
 		"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
 )
@@ -60,6 +69,11 @@ type Service struct {
 
 	mu   sync.RWMutex
 	snap Snapshot
+
+	// names caches subject ID -> resolved English title so refreshes only
+	// pay the subject_abstract call for subjects new to the charts. Only
+	// successful resolutions are cached; failures retry next interval.
+	names map[string]string
 }
 
 // New builds a Service; call Run to start refreshing.
@@ -79,6 +93,7 @@ func New(cfg Config) *Service {
 	return &Service{
 		cfg:    cfg,
 		client: &http.Client{Timeout: fetchTimeout},
+		names:  make(map[string]string),
 	}
 }
 
@@ -105,10 +120,11 @@ func (s *Service) Run(ctx context.Context) {
 }
 
 // refresh fetches both lists. A list that fails keeps its previous value, so
-// one bad response never blanks the homepage section.
+// one bad response never blanks the homepage section. Movies use Douban's
+// 欧美 tag, TV the 美剧 tag (the tv type has no 欧美 tag).
 func (s *Service) refresh(ctx context.Context) {
-	movies, errM := s.fetchList(ctx, "movie")
-	tv, errT := s.fetchList(ctx, "tv")
+	movies, errM := s.fetchList(ctx, "movie", "欧美")
+	tv, errT := s.fetchList(ctx, "tv", "美剧")
 	if errM != nil {
 		s.cfg.Logger.Printf("trending: movie fetch: %v", errM)
 	}
@@ -129,10 +145,123 @@ func (s *Service) refresh(ctx context.Context) {
 	s.snap.UpdatedAt = time.Now()
 }
 
-// fetchList pulls one 热门 list ("movie" or "tv") and returns its titles.
-func (s *Service) fetchList(ctx context.Context, typ string) ([]string, error) {
+type subject struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+}
+
+// fetchList pulls one chart and returns its titles, resolved to English
+// names where possible.
+func (s *Service) fetchList(ctx context.Context, typ, tag string) ([]string, error) {
 	u := fmt.Sprintf("%s/j/search_subjects?type=%s&tag=%s&page_limit=%d&page_start=0",
-		s.cfg.BaseURL, typ, url.QueryEscape("热门"), s.cfg.Limit)
+		s.cfg.BaseURL, typ, url.QueryEscape(tag), s.cfg.Limit)
+	body, err := s.get(ctx, u)
+	if err != nil {
+		return nil, err
+	}
+	var payload struct {
+		Subjects []subject `json:"subjects"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	if len(payload.Subjects) == 0 {
+		// A 200 with no subjects usually means Douban changed the response
+		// shape or is soft-blocking; treat as failure to keep the last list.
+		return nil, fmt.Errorf("no subjects in response")
+	}
+	titles := make([]string, 0, len(payload.Subjects))
+	for _, sub := range payload.Subjects {
+		if sub.Title == "" {
+			continue
+		}
+		titles = append(titles, s.englishTitle(ctx, sub))
+	}
+	if len(titles) == 0 {
+		return nil, fmt.Errorf("no titles in response")
+	}
+	return titles, nil
+}
+
+// englishTitle resolves a subject's English name via subject_abstract,
+// falling back to the Chinese chart title when resolution fails.
+func (s *Service) englishTitle(ctx context.Context, sub subject) string {
+	s.mu.RLock()
+	cached, ok := s.names[sub.ID]
+	s.mu.RUnlock()
+	if ok {
+		return cached
+	}
+	time.Sleep(abstractDelay)
+	u := fmt.Sprintf("%s/j/subject_abstract?subject_id=%s", s.cfg.BaseURL, url.QueryEscape(sub.ID))
+	body, err := s.get(ctx, u)
+	if err != nil {
+		s.cfg.Logger.Printf("trending: abstract %s: %v", sub.ID, err)
+		return sub.Title
+	}
+	var payload struct {
+		Subject struct {
+			Title string `json:"title"`
+		} `json:"subject"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		s.cfg.Logger.Printf("trending: abstract %s: decode: %v", sub.ID, err)
+		return sub.Title
+	}
+	name := extractEnglish(payload.Subject.Title, sub.Title)
+	if name == "" {
+		// Chinese-only production (or an unexpected format): the chart title
+		// is the best keyword there is. Cache it — retrying won't improve it.
+		name = sub.Title
+	}
+	s.mu.Lock()
+	s.names[sub.ID] = name
+	s.mu.Unlock()
+	return name
+}
+
+// yearSuffix matches the trailing " (2026)" on abstract titles.
+var yearSuffix = regexp.MustCompile(`\s*\(\d{4}\)\s*$`)
+
+// hasLetter requires at least one ASCII letter for a string to count as an
+// English name.
+var hasLetter = regexp.MustCompile(`[A-Za-z]`)
+
+// extractEnglish pulls the original English name out of an abstract title of
+// the form "中文名 English Name‎ (2026)", given the chart's Chinese title.
+// Returns "" when there is no such name.
+func extractEnglish(full, chinese string) string {
+	full = yearSuffix.ReplaceAllString(full, "")
+	var name string
+	if chinese != "" && strings.HasPrefix(full, chinese) {
+		// Exact prefix strip. This is the reliable path: a Chinese title
+		// that ends in digits ("疯狂动物城2 Zootopia 2") defeats any
+		// per-rune classification.
+		name = full[len(chinese):]
+	} else {
+		// Chart and abstract titles disagree; fall back to everything after
+		// the last CJK rune.
+		cut := 0
+		for i, r := range full {
+			if unicode.In(r, unicode.Han, unicode.Hiragana, unicode.Katakana, unicode.Hangul) {
+				cut = i + len(string(r))
+			}
+		}
+		name = full[cut:]
+	}
+	// Trim whitespace and invisible format runes — Douban embeds a U+200E
+	// LEFT-TO-RIGHT MARK after the original name (Cf, not graphic).
+	name = strings.TrimFunc(name, func(r rune) bool {
+		return unicode.IsSpace(r) || !unicode.IsGraphic(r)
+	})
+	if !hasLetter.MatchString(name) {
+		return ""
+	}
+	return name
+}
+
+// get performs one browser-shaped GET and returns the body.
+func (s *Service) get(ctx context.Context, u string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return nil, err
@@ -147,28 +276,5 @@ func (s *Service) fetchList(ctx context.Context, typ string) ([]string, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("status %d", resp.StatusCode)
 	}
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBody))
-	if err != nil {
-		return nil, err
-	}
-	var payload struct {
-		Subjects []struct {
-			Title string `json:"title"`
-		} `json:"subjects"`
-	}
-	if err := json.Unmarshal(body, &payload); err != nil {
-		return nil, fmt.Errorf("decode: %w", err)
-	}
-	titles := make([]string, 0, len(payload.Subjects))
-	for _, sub := range payload.Subjects {
-		if sub.Title != "" {
-			titles = append(titles, sub.Title)
-		}
-	}
-	if len(titles) == 0 {
-		// A 200 with no subjects usually means Douban changed the response
-		// shape or is soft-blocking; treat as failure to keep the last list.
-		return nil, fmt.Errorf("no titles in response")
-	}
-	return titles, nil
+	return io.ReadAll(io.LimitReader(resp.Body, maxBody))
 }

--- a/server/internal/trending/trending_test.go
+++ b/server/internal/trending/trending_test.go
@@ -5,45 +5,77 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 )
 
-func TestFetchAndKeepLastGood(t *testing.T) {
-	var fail bool
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if fail {
+// stub mimics the two Douban endpoints: charts with Chinese titles, and
+// per-subject abstracts carrying "中文 English‎ (year)" titles.
+func stub(fail *atomic.Bool, abstractCalls *atomic.Int64) http.Handler {
+	abstracts := map[string]string{
+		"1": "痴迷 Obsession‎ (2025)",
+		"2": "瑞克和莫蒂 第九季 Rick and Morty Season 9‎ (2026)",
+		"3": "无名之辈‎ (2018)", // Chinese-only: no English name
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fail != nil && fail.Load() {
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}
-		typ := r.URL.Query().Get("type")
-		fmt.Fprintf(w, `{"subjects":[{"title":"%s-one"},{"title":"%s-two"}]}`, typ, typ)
-	}))
+		switch r.URL.Path {
+		case "/j/search_subjects":
+			switch r.URL.Query().Get("type") {
+			case "movie":
+				fmt.Fprint(w, `{"subjects":[{"id":"1","title":"痴迷"},{"id":"3","title":"无名之辈"}]}`)
+			default:
+				fmt.Fprint(w, `{"subjects":[{"id":"2","title":"瑞克和莫蒂 第九季"}]}`)
+			}
+		case "/j/subject_abstract":
+			abstractCalls.Add(1)
+			fmt.Fprintf(w, `{"subject":{"title":"%s"}}`, abstracts[r.URL.Query().Get("subject_id")])
+		default:
+			http.NotFound(w, r)
+		}
+	})
+}
+
+func TestFetchResolvesEnglishTitles(t *testing.T) {
+	var fail atomic.Bool
+	var calls atomic.Int64
+	srv := httptest.NewServer(stub(&fail, &calls))
 	defer srv.Close()
 
 	svc := New(Config{BaseURL: srv.URL, Interval: time.Hour})
 	svc.refresh(context.Background())
 
 	snap := svc.Get()
-	if got := snap.Movies; len(got) != 2 || got[0] != "movie-one" {
+	if got := snap.Movies; len(got) != 2 || got[0] != "Obsession" || got[1] != "无名之辈" {
 		t.Fatalf("movies = %v", got)
 	}
-	if got := snap.TV; len(got) != 2 || got[1] != "tv-two" {
+	if got := snap.TV; len(got) != 1 || got[0] != "Rick and Morty Season 9" {
 		t.Fatalf("tv = %v", got)
 	}
 	if snap.UpdatedAt.IsZero() {
 		t.Fatal("UpdatedAt not set")
 	}
 
+	// Second refresh must serve names from the cache: no new abstract calls.
+	before := calls.Load()
+	svc.refresh(context.Background())
+	if calls.Load() != before {
+		t.Fatalf("abstract calls after cached refresh: %d -> %d", before, calls.Load())
+	}
+
 	// Upstream breaks: the previous snapshot must survive untouched.
-	fail = true
-	before := svc.Get()
+	fail.Store(true)
+	prev := svc.Get()
 	svc.refresh(context.Background())
 	after := svc.Get()
-	if len(after.Movies) != 2 || len(after.TV) != 2 {
+	if len(after.Movies) != 2 || len(after.TV) != 1 {
 		t.Fatalf("snapshot lost after failed refresh: %+v", after)
 	}
-	if !after.UpdatedAt.Equal(before.UpdatedAt) {
+	if !after.UpdatedAt.Equal(prev.UpdatedAt) {
 		t.Fatal("UpdatedAt advanced on a fully failed refresh")
 	}
 }
@@ -55,7 +87,26 @@ func TestEmptySubjectsIsError(t *testing.T) {
 	defer srv.Close()
 
 	svc := New(Config{BaseURL: srv.URL})
-	if _, err := svc.fetchList(context.Background(), "movie"); err == nil {
+	if _, err := svc.fetchList(context.Background(), "movie", "欧美"); err == nil {
 		t.Fatal("expected error for empty subjects")
+	}
+}
+
+func TestExtractEnglish(t *testing.T) {
+	cases := []struct{ in, chinese, want string }{
+		{"痴迷 Obsession‎ (2025)", "痴迷", "Obsession"},
+		{"瑞克和莫蒂 第九季 Rick and Morty Season 9‎ (2026)", "瑞克和莫蒂 第九季", "Rick and Morty Season 9"},
+		{"柯蒂斯总统 第一季 President Curtis Season 1‎ (2026)", "柯蒂斯总统 第一季", "President Curtis Season 1"},
+		{"无名之辈‎ (2018)", "无名之辈", ""},     // no English name
+		{"寒战1994‎ (1994)", "寒战1994", ""}, // digit-tailed Chinese title, nothing after
+		{"疯狂动物城2 Zootopia 2‎ (2025)", "疯狂动物城2", "Zootopia 2"},
+		{"V字仇杀队 V for Vendetta‎ (2005)", "V字仇杀队", "V for Vendetta"},
+		// Chart/abstract mismatch falls back to the last-CJK heuristic.
+		{"痴迷 Obsession‎ (2025)", "different", "Obsession"},
+	}
+	for _, c := range cases {
+		if got := extractEnglish(c.in, c.chinese); got != c.want {
+			t.Errorf("extractEnglish(%q, %q) = %q, want %q", c.in, c.chinese, got, c.want)
+		}
 	}
 }


### PR DESCRIPTION
Follow-up to #32, per request: only Western trending titles, with English names as the quick-search keywords (they match torrent names far better than Chinese titles).

- Movies now pull Douban's **欧美** tag; TV pulls **美剧** (the `tv` type has no 欧美 tag — verified it returns empty).
- Each subject's English name comes from `/j/subject_abstract`, whose title has the form `中文名 English Name<U+200E> (year)`. Extraction strips the chart's Chinese title as an **exact prefix**; a pure last-CJK-rune heuristic mis-split digit-tailed titles (疯狂动物城2 → "2 Zootopia 2" instead of "Zootopia 2" — caught in live testing, now unit-tested).
- Resolutions are cached by subject ID: steady-state refresh cost stays ~2 requests/hour, with 500ms spacing on cold start.
- Chinese-only titles (no original English name) fall back to the chart title as the keyword.

Live output now: movies `Obsession, The Shawshank Redemption, Zootopia 2, …`; tv `Rick and Morty Season 9, Hacks Season 5, House of the Dragon Season 3, …`

`gofmt`, `go vet`, `go test`, `go build` all pass; frontend untouched.