### PR TITLE
Trending: add 日剧 and 韩剧 rows to homepage

### DIFF
--- a/env.example
+++ b/env.example
@@ -70,9 +70,10 @@ SCRAPE_ENABLED=true
 # TRACKERS=udp://tracker.opentrackr.org:1337/announce,udp://open.demonii.com:1337/announce,udp://tracker.torrent.eu.org:451/announce,udp://exodus.desync.com:6969/announce
 
 # --- Douban trending (homepage quick-search chips) ---
-# Hourly fetch of Douban's trending Western movies (欧美 tag) and US TV
-# shows (美剧 tag), resolved to their English names via one extra
-# subject_abstract call per newly-charted title (cached by subject ID).
+# Hourly fetch of Douban's trending charts: 欧美 movies and 美剧 resolved
+# to their English names via one extra subject_abstract call per
+# newly-charted title (cached by subject ID); 日剧 and 韩剧 keep their
+# Chinese chart titles (what Chinese release names use).
 # On failure the last good list keeps serving; if it never succeeds the
 # homepage just hides the section.
 # TRENDING_ENABLED=true

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -309,7 +309,12 @@ func main() {
 		go svc.Run(ctx)
 		trendFn = func() api.Trending {
 			snap := svc.Get()
-			t := api.Trending{Movies: snap.Movies, TV: snap.TV}
+			t := api.Trending{
+				Movies: snap.Movies,
+				TV:     snap.TV,
+				TVJP:   snap.TVJP,
+				TVKR:   snap.TVKR,
+			}
 			if !snap.UpdatedAt.IsZero() {
 				t.UpdatedAt = snap.UpdatedAt.Unix()
 			}

--- a/server/internal/api/api.go
+++ b/server/internal/api/api.go
@@ -60,8 +60,10 @@ type Options struct {
 // Trending is the payload for /api/trending: Douban's current hot movie and
 // TV titles, for the homepage's quick-search chips.
 type Trending struct {
-	Movies    []string `json:"movies"`
-	TV        []string `json:"tv"`
+	Movies    []string `json:"movies"` // 欧美 movies, English names
+	TV        []string `json:"tv"`     // 美剧, English names
+	TVJP      []string `json:"tv_jp"`  // 日剧, Chinese names
+	TVKR      []string `json:"tv_kr"`  // 韩剧, Chinese names
 	UpdatedAt int64    `json:"updated_at"`
 }
 
@@ -353,14 +355,18 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleTrending(w http.ResponseWriter, r *http.Request) {
-	t := Trending{Movies: []string{}, TV: []string{}}
+	t := Trending{Movies: []string{}, TV: []string{}, TVJP: []string{}, TVKR: []string{}}
 	if s.opts.Trending != nil {
 		got := s.opts.Trending()
-		if got.Movies != nil {
-			t.Movies = got.Movies
-		}
-		if got.TV != nil {
-			t.TV = got.TV
+		for dst, src := range map[*[]string][]string{
+			&t.Movies: got.Movies,
+			&t.TV:     got.TV,
+			&t.TVJP:   got.TVJP,
+			&t.TVKR:   got.TVKR,
+		} {
+			if src != nil {
+				*dst = src
+			}
 		}
 		t.UpdatedAt = got.UpdatedAt
 	}

--- a/server/internal/trending/trending.go
+++ b/server/internal/trending/trending.go
@@ -55,10 +55,12 @@ type Config struct {
 	Logger  *log.Logger
 }
 
-// Snapshot is the current trending state. Slices are never nil.
+// Snapshot is the current trending state.
 type Snapshot struct {
-	Movies    []string
-	TV        []string
+	Movies    []string // 欧美 movies
+	TV        []string // 美剧
+	TVJP      []string // 日剧
+	TVKR      []string // 韩剧
 	UpdatedAt time.Time
 }
 
@@ -119,28 +121,44 @@ func (s *Service) Run(ctx context.Context) {
 	}
 }
 
-// refresh fetches both lists. A list that fails keeps its previous value, so
-// one bad response never blanks the homepage section. Movies use Douban's
-// 欧美 tag, TV the 美剧 tag (the tv type has no 欧美 tag).
+// charts are the Douban lists backing the homepage rows. Western charts
+// resolve each subject's English name (torrent names carry those); Japanese
+// and Korean dramas keep the Chinese chart title, which is what Chinese
+// release names use.
+var charts = []struct {
+	typ, tag string
+	english  bool
+	apply    func(*Snapshot, []string)
+}{
+	{"movie", "欧美", true, func(sn *Snapshot, t []string) { sn.Movies = t }},
+	{"tv", "美剧", true, func(sn *Snapshot, t []string) { sn.TV = t }},
+	{"tv", "日剧", false, func(sn *Snapshot, t []string) { sn.TVJP = t }},
+	{"tv", "韩剧", false, func(sn *Snapshot, t []string) { sn.TVKR = t }},
+}
+
+// refresh fetches every chart. A chart that fails keeps its previous value,
+// so one bad response never blanks a homepage row.
 func (s *Service) refresh(ctx context.Context) {
-	movies, errM := s.fetchList(ctx, "movie", "欧美")
-	tv, errT := s.fetchList(ctx, "tv", "美剧")
-	if errM != nil {
-		s.cfg.Logger.Printf("trending: movie fetch: %v", errM)
+	type result struct {
+		apply  func(*Snapshot, []string)
+		titles []string
 	}
-	if errT != nil {
-		s.cfg.Logger.Printf("trending: tv fetch: %v", errT)
+	var ok []result
+	for _, c := range charts {
+		titles, err := s.fetchList(ctx, c.typ, c.tag, c.english)
+		if err != nil {
+			s.cfg.Logger.Printf("trending: %s/%s fetch: %v", c.typ, c.tag, err)
+			continue
+		}
+		ok = append(ok, result{c.apply, titles})
 	}
-	if errM != nil && errT != nil {
+	if len(ok) == 0 {
 		return
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if errM == nil {
-		s.snap.Movies = movies
-	}
-	if errT == nil {
-		s.snap.TV = tv
+	for _, r := range ok {
+		r.apply(&s.snap, r.titles)
 	}
 	s.snap.UpdatedAt = time.Now()
 }
@@ -150,9 +168,9 @@ type subject struct {
 	Title string `json:"title"`
 }
 
-// fetchList pulls one chart and returns its titles, resolved to English
-// names where possible.
-func (s *Service) fetchList(ctx context.Context, typ, tag string) ([]string, error) {
+// fetchList pulls one chart and returns its titles; english resolves each
+// title to the subject's English name where one exists.
+func (s *Service) fetchList(ctx context.Context, typ, tag string, english bool) ([]string, error) {
 	u := fmt.Sprintf("%s/j/search_subjects?type=%s&tag=%s&page_limit=%d&page_start=0",
 		s.cfg.BaseURL, typ, url.QueryEscape(tag), s.cfg.Limit)
 	body, err := s.get(ctx, u)
@@ -175,7 +193,11 @@ func (s *Service) fetchList(ctx context.Context, typ, tag string) ([]string, err
 		if sub.Title == "" {
 			continue
 		}
-		titles = append(titles, s.englishTitle(ctx, sub))
+		if english {
+			titles = append(titles, s.englishTitle(ctx, sub))
+		} else {
+			titles = append(titles, sub.Title)
+		}
 	}
 	if len(titles) == 0 {
 		return nil, fmt.Errorf("no titles in response")

--- a/server/internal/trending/trending_test.go
+++ b/server/internal/trending/trending_test.go
@@ -25,9 +25,13 @@ func stub(fail *atomic.Bool, abstractCalls *atomic.Int64) http.Handler {
 		}
 		switch r.URL.Path {
 		case "/j/search_subjects":
-			switch r.URL.Query().Get("type") {
-			case "movie":
+			switch tag := r.URL.Query().Get("tag"); {
+			case r.URL.Query().Get("type") == "movie":
 				fmt.Fprint(w, `{"subjects":[{"id":"1","title":"痴迷"},{"id":"3","title":"无名之辈"}]}`)
+			case tag == "日剧":
+				fmt.Fprint(w, `{"subjects":[{"id":"4","title":"直到T恤干透"}]}`)
+			case tag == "韩剧":
+				fmt.Fprint(w, `{"subjects":[{"id":"5","title":"铁拳教育"}]}`)
 			default:
 				fmt.Fprint(w, `{"subjects":[{"id":"2","title":"瑞克和莫蒂 第九季"}]}`)
 			}
@@ -56,6 +60,16 @@ func TestFetchResolvesEnglishTitles(t *testing.T) {
 	if got := snap.TV; len(got) != 1 || got[0] != "Rick and Morty Season 9" {
 		t.Fatalf("tv = %v", got)
 	}
+	// JP/KR charts keep Chinese titles and must not hit subject_abstract.
+	if got := snap.TVJP; len(got) != 1 || got[0] != "直到T恤干透" {
+		t.Fatalf("tv_jp = %v", got)
+	}
+	if got := snap.TVKR; len(got) != 1 || got[0] != "铁拳教育" {
+		t.Fatalf("tv_kr = %v", got)
+	}
+	if calls.Load() != 3 {
+		t.Fatalf("abstract calls = %d, want 3 (english charts only)", calls.Load())
+	}
 	if snap.UpdatedAt.IsZero() {
 		t.Fatal("UpdatedAt not set")
 	}
@@ -72,7 +86,7 @@ func TestFetchResolvesEnglishTitles(t *testing.T) {
 	prev := svc.Get()
 	svc.refresh(context.Background())
 	after := svc.Get()
-	if len(after.Movies) != 2 || len(after.TV) != 1 {
+	if len(after.Movies) != 2 || len(after.TV) != 1 || len(after.TVJP) != 1 || len(after.TVKR) != 1 {
 		t.Fatalf("snapshot lost after failed refresh: %+v", after)
 	}
 	if !after.UpdatedAt.Equal(prev.UpdatedAt) {
@@ -87,7 +101,7 @@ func TestEmptySubjectsIsError(t *testing.T) {
 	defer srv.Close()
 
 	svc := New(Config{BaseURL: srv.URL})
-	if _, err := svc.fetchList(context.Background(), "movie", "欧美"); err == nil {
+	if _, err := svc.fetchList(context.Background(), "movie", "欧美", true); err == nil {
 		t.Fatal("expected error for empty subjects")
 	}
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -23,8 +23,12 @@ function TrendingRow({ label, titles }: { label: string; titles: string[] }) {
 
 export default async function Home() {
   const [stats, trending] = await Promise.all([fetchStats(), fetchTrending()]);
-  const movies = trending?.movies ?? [];
-  const tv = trending?.tv ?? [];
+  const rows = [
+    { label: "热门电影", titles: trending?.movies ?? [] },
+    { label: "热门美剧", titles: trending?.tv ?? [] },
+    { label: "热门日剧", titles: trending?.tv_jp ?? [] },
+    { label: "热门韩剧", titles: trending?.tv_kr ?? [] },
+  ].filter((r) => r.titles.length > 0);
 
   return (
     <main className="flex flex-1 flex-col items-center justify-center px-4 py-16">
@@ -47,10 +51,11 @@ export default async function Home() {
           直接输入关键词搜索，留空则浏览最新收录的资源
         </p>
 
-        {(movies.length > 0 || tv.length > 0) && (
+        {rows.length > 0 && (
           <div className="mt-8">
-            {movies.length > 0 && <TrendingRow label="热门电影" titles={movies} />}
-            {tv.length > 0 && <TrendingRow label="热门剧集" titles={tv} />}
+            {rows.map((r) => (
+              <TrendingRow key={r.label} label={r.label} titles={r.titles} />
+            ))}
             <p className="mt-2 text-center text-[10px] text-zinc-600">
               热门影视数据来自豆瓣
             </p>

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -85,6 +85,8 @@ export async function fetchSearch(
 export interface TrendingResponse {
   movies?: string[];
   tv?: string[];
+  tv_jp?: string[];
+  tv_kr?: string[];
   updated_at?: number;
 }
 


### PR DESCRIPTION
Adds two more trending rows to the homepage: **热门日剧** and **热门韩剧** (existing 热门剧集 renamed 热门美剧).

- Charts are now table-driven in the trending package: type/tag/english-resolution per chart.
- Per request, 日剧 and 韩剧 keep their **Chinese chart titles** as keywords — Chinese release names use those — so they skip the subject_abstract English-resolution calls entirely (no extra request cost).
- `/api/trending` gains `tv_jp` and `tv_kr` fields; the homepage renders whichever rows have data.

Tests cover the new charts, including that JP/KR fetches make zero abstract calls. `gofmt`/`go vet`/`go test`/`go build` and `npm run lint`/`npm run build` all pass.