### PR TITLE
trackers: add ACG fansub + US/KR/JP TV trackers to defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,14 @@ seeder 数，然后按 seeder 数从高到低喂给获取端——热门资源�
 身就在提升吞吐。
 
 同一份 `TRACKERS` 列表还会以 `&tr=` 附在获取端的磁力链接上：tracker 一次往返就
-能拿到 peer 列表，省掉吃掉大半 `META_TIMEOUT` 的 DHT 找 peer 游走。
+能拿到 peer 列表，省掉吃掉大半 `META_TIMEOUT` 的 DHT 找 peer 游走。默认列表分
+两类：UDP 的大型 open tracker（opentrackr、demonii 等，外加美剧/韩剧/日剧发布
+——EZTV 及各类 TV 资源——常挂的 open.stealth.si、tracker.dler.org、tracker.qu.ax、
+tracker-udp.gbitt.info），既参与 scrape 排序也作 peer 提示；以及中国字幕组发布
+（动漫花园 / 蜜柑 / Nyaa 上的桜都、喵萌、北宇治等）常用的 HTTP tracker
+（nyaa.tracker.wf、t.nyaatracker.com、opentracker.acgnx.se）——HTTP 不能参与
+BEP 15 scrape，只作 peer 提示，但字幕组种子的 peer 往往只在这些 tracker 上，
+加了才能在超时内拿到 metadata。
 
 看 `/api/stats` 的 `scraper` 段：`seeded/scraped` 是命中率（有 seeder 的占比），
 `queue` 是排队深度，`evicted` 是被挤掉的低优先级 hash，`scrape_errors` 持续增长

--- a/env.example
+++ b/env.example
@@ -65,9 +65,13 @@ META_WORKERS=128
 SCRAPE_ENABLED=true
 # Comma-separated announce URLs. Also appended to fetch magnets as &tr= peer
 # hints, which shortcuts the DHT peer walk that eats most of META_TIMEOUT.
-# Only udp:// entries can be scraped; keep to the big open trackers that are
-# built for this volume.
-# TRACKERS=udp://tracker.opentrackr.org:1337/announce,udp://open.demonii.com:1337/announce,udp://tracker.torrent.eu.org:451/announce,udp://exodus.desync.com:6969/announce
+# Only udp:// entries can be scraped; keep those to the big open trackers
+# that are built for this volume — the defaults include the ones US/KR/JP
+# TV (美剧/韩剧/日剧, EZTV etc.) releases announce to. http(s):// entries
+# are peer-hint-only — the defaults include the ACG trackers Chinese
+# fansub (字幕组) releases announce to (Nyaa, AcgnX), which is what gets
+# those swarms fetched.
+# TRACKERS=udp://tracker.opentrackr.org:1337/announce,udp://open.demonii.com:1337/announce,udp://tracker.torrent.eu.org:451/announce,udp://exodus.desync.com:6969/announce,udp://open.stealth.si:80/announce,udp://tracker.dler.org:6969/announce,udp://tracker.qu.ax:6969/announce,udp://tracker-udp.gbitt.info:80/announce,http://nyaa.tracker.wf:7777/announce,http://t.nyaatracker.com/announce,http://opentracker.acgnx.se/announce
 
 # --- Douban trending (homepage quick-search chips) ---
 # Hourly fetch of Douban's trending charts: 欧美 movies and 美剧 resolved

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -28,10 +28,27 @@ import (
 // defaultTrackers are large, long-lived open trackers. They serve both
 // pipeline roles (scrape ranking and magnet peer hints); the list is
 // overridable via TRACKERS for when one of them inevitably goes away.
+// The second udp block are the open trackers US/KR/JP TV (美剧/韩剧/日剧)
+// releases (EZTV and friends) announce to — scrapeable, so they also widen
+// seeder-ranking coverage for those swarms. The http:// entries are the ACG
+// trackers Chinese fansub groups (字幕组) announce to — Nyaa's and AcgnX's,
+// carried by dmhy/Mikan/bangumi.moe releases. Only udp:// entries are
+// scrapeable, so http ones contribute peer hints only, but for fansub
+// swarms that hint is what makes metadata fetch land inside META_TIMEOUT.
+// All entries probed alive 2026-08 from both deploy vantage points;
+// notable dead ones checked: t.acg.rip, tr.bangumi.moe,
+// open.acgnxtracker.com, explodie.org (local), tracker.ololosh.space.
 const defaultTrackers = "udp://tracker.opentrackr.org:1337/announce," +
 	"udp://open.demonii.com:1337/announce," +
 	"udp://tracker.torrent.eu.org:451/announce," +
-	"udp://exodus.desync.com:6969/announce"
+	"udp://exodus.desync.com:6969/announce," +
+	"udp://open.stealth.si:80/announce," +
+	"udp://tracker.dler.org:6969/announce," +
+	"udp://tracker.qu.ax:6969/announce," +
+	"udp://tracker-udp.gbitt.info:80/announce," +
+	"http://nyaa.tracker.wf:7777/announce," +
+	"http://t.nyaatracker.com/announce," +
+	"http://opentracker.acgnx.se/announce"
 
 // envDefault returns the env value or fallback.
 func envDefault(key, fallback string) string {


### PR DESCRIPTION
## 目的

让中国字幕组(动漫花园 / 蜜柑 / Nyaa 上的桜都、喵萌、北宇治等)以及美剧/韩剧/日剧(EZTV 等)的种子更容易被索引到。

## 新增 tracker(全部于 2026-08 从本机爬虫和 sf.maxlv.net 两个 vantage 探活)

**UDP(可 BEP 15 scrape,同时扩大 TV 剧集 swarm 的 seeder 排序覆盖):**
- `udp://open.stealth.si:80/announce`
- `udp://tracker.dler.org:6969/announce`
- `udp://tracker.qu.ax:6969/announce`
- `udp://tracker-udp.gbitt.info:80/announce`

**HTTP(仅作磁力 `&tr=` peer 提示,是字幕组发布实际 announce 的 tracker):**
- `http://nyaa.tracker.wf:7777/announce`
- `http://t.nyaatracker.com/announce`
- `http://opentracker.acgnx.se/announce`(返回有效 bencode;注册制,对 AcgnX/动漫花园已发布种子有效)

## 探测为死、明确排除

t.acg.rip(解析到内网 10.255.255.254)、tr.bangumi.moe(超时)、open.acgnxtracker.com(NXDOMAIN)、open.acgtracker.com、tracker.kamigami.org、share.camoe.cn、tracker.nanoha.org、explodie.org / tracker.ololosh.space(本机 vantage 不可达)。

## 影响面

- scraper 对非 udp 条目只在启动时打一行 skip 日志,行为不变;udp scrape 每批并行多问 4 个 tracker,取最大 seeder 数。
- fetch 磁力后缀多 7 个 `&tr=` 参数。
- `gofmt` / `go build` / `go vet` / `go test ./...` 全部通过。